### PR TITLE
fix: prepend consensus state

### DIFF
--- a/x/interchainqueries/keeper/msg_server.go
+++ b/x/interchainqueries/keeper/msg_server.go
@@ -54,7 +54,7 @@ func (k msgServer) SubmitQueryResult(goCtx context.Context, msg *types.MsgSubmit
 
 	resp, err := k.ibcKeeper.ConnectionConsensusState(goCtx, &ibcconnectiontypes.QueryConnectionConsensusStateRequest{
 		ConnectionId:   query.ConnectionId,
-		RevisionNumber: 2,
+		RevisionNumber: 2, // TODO: this should not be hard-coded.
 		RevisionHeight: msg.Result.Height + 1,
 	})
 	if err != nil {

--- a/x/interchainqueries/keeper/msg_server.go
+++ b/x/interchainqueries/keeper/msg_server.go
@@ -54,8 +54,8 @@ func (k msgServer) SubmitQueryResult(goCtx context.Context, msg *types.MsgSubmit
 
 	resp, err := k.ibcKeeper.ConnectionConsensusState(goCtx, &ibcconnectiontypes.QueryConnectionConsensusStateRequest{
 		ConnectionId:   query.ConnectionId,
-		RevisionNumber: 1,
-		RevisionHeight: msg.Result.Height,
+		RevisionNumber: 2,
+		RevisionHeight: msg.Result.Height + 1,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get consensus state: %w", err)


### PR DESCRIPTION
this PR makes it possible to submit normal queries by fixing the requested consensus state height & fixing the revision number.

please note that the revision number should not be hardcoded, but this is out of the scope  of this PR