### PR TITLE
Fix: bump Debian version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster
+FROM golang:1.18-bullseye
 EXPOSE 16657
 EXPOSE 16656
 EXPOSE 6060


### PR DESCRIPTION
Buster provides glibc 2.28 and Bullseye provides 2.31.

Hermes needs at least glibc 2.29 in order to run.