### PR TITLE
feat: no build on run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,19 @@ EXPOSE 1317
 EXPOSE 9090 
 EXPOSE 9091
 EXPOSE 8081
-
 ADD . /opt/neutron
-RUN PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
+RUN cd /opt/neutron && make install && PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
     curl -L "https://github.com/informalsystems/ibc-rs/releases/download/v0.14.1/hermes-v0.14.1-${PLATFORM}-unknown-linux-gnu.tar.gz" > hermes.tar.gz && \
     mkdir -p $HOME/.hermes/bin && \
     tar -C $HOME/.hermes/bin/ -vxzf hermes.tar.gz && \
-    rm -f hermes.tar.gz
+    rm -f hermes.tar.gz 
 ENV PATH="/root/.hermes/bin:${PATH}"
 WORKDIR /opt/neutron
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD \
     curl -f http://127.0.0.1:1317/blocks/1 >/dev/null 2>&1 || exit 1
-CMD ls -la && make init && hermes -c ./network/hermes/config.toml create channel --port-a transfer --port-b transfer test-1 connection-0 && make start-rly 
+CMD ./network/init.sh && \
+	./network/start.sh && \
+	./network/hermes/restore-keys.sh && \
+	./network/hermes/create-conn.sh && \
+    hermes -c ./network/hermes/config.toml create channel --port-a transfer --port-b transfer test-1 connection-0 && \
+    ./network/hermes/start.sh


### PR DESCRIPTION
There was an issue with build phase on every run of container. Now `neutrond` is built on image build. 

PS: I have no success on separating build process on 2 phases bc when I copy binary of neutron from build phase to regular it can't be executed (this issue I believe only for M1) so I left this stuff in one phase.