### PR TITLE
Chore: create channel in hermes network scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ EXPOSE 9090
 EXPOSE 9091
 EXPOSE 8081
 ADD . /opt/neutron
-RUN cd /opt/neutron && make install && PLATFORM=`uname -a | awk '{print $(NF-1)}'` && \
+RUN cd /opt/neutron && make install && PLATFORM=`uname -m` && \
     curl -L "https://github.com/informalsystems/ibc-rs/releases/download/v0.14.1/hermes-v0.14.1-${PLATFORM}-unknown-linux-gnu.tar.gz" > hermes.tar.gz && \
     mkdir -p $HOME/.hermes/bin && \
     tar -C $HOME/.hermes/bin/ -vxzf hermes.tar.gz && \
@@ -26,5 +26,4 @@ CMD ./network/init.sh && \
 	./network/start.sh && \
 	./network/hermes/restore-keys.sh && \
 	./network/hermes/create-conn.sh && \
-    hermes -c ./network/hermes/config.toml create channel --port-a transfer --port-b transfer test-1 connection-0 && \
     ./network/hermes/start.sh

--- a/network/hermes/create-conn.sh
+++ b/network/hermes/create-conn.sh
@@ -9,3 +9,4 @@ echo "Initiating connection handshake..."
 $HERMES_BINARY -c $CONFIG_DIR create connection test-1 test-2
 
 sleep 2
+hermes -c ./network/hermes/config.toml create channel --port-a transfer --port-b transfer test-1 connection-0


### PR DESCRIPTION
Without this PR, `make init` didn't create a channel, leaving Docker and "native" setups to remain slightly different.