### PR TITLE
Fix: transfer from a non-contract account works

### DIFF
--- a/x/transfer/ibc_handlers.go
+++ b/x/transfer/ibc_handlers.go
@@ -94,7 +94,10 @@ func (im IBCModule) HandleAcknowledgement(ctx sdk.Context, packet channeltypes.P
 	ctx.GasMeter().ConsumeGas(newGasMeter.GasConsumed(), "consume from cached context")
 	im.keeper.Logger(ctx).Debug("acknowledgement received", "Packet data", data, "CheckTx", ctx.IsCheckTx())
 
-	im.wrappedKeeper.FeeKeeper.DistributeAcknowledgementFee(ctx, relayer, feetypes.NewPacketID(packet.SourcePort, packet.SourceChannel, packet.Sequence))
+	// distribute fees only if the sender is a contract
+	if im.ContractManagerKeeper.HasContractInfo(ctx, senderAddress) {
+		im.wrappedKeeper.FeeKeeper.DistributeAcknowledgementFee(ctx, relayer, feetypes.NewPacketID(packet.SourcePort, packet.SourceChannel, packet.Sequence))
+	}
 
 	return nil
 }
@@ -124,7 +127,11 @@ func (im IBCModule) HandleTimeout(ctx sdk.Context, packet channeltypes.Packet, r
 		writeFn()
 	}
 
-	im.wrappedKeeper.FeeKeeper.DistributeTimeoutFee(ctx, relayer, feetypes.NewPacketID(packet.SourcePort, packet.SourceChannel, packet.Sequence))
+	// distribute fee only if the sender is a contract
+	if im.ContractManagerKeeper.HasContractInfo(ctx, senderAddress) {
+		im.wrappedKeeper.FeeKeeper.DistributeTimeoutFee(ctx, relayer, feetypes.NewPacketID(packet.SourcePort, packet.SourceChannel, packet.Sequence))
+	}
+
 	ctx.GasMeter().ConsumeGas(newGasMeter.GasConsumed(), "consume from cached context")
 
 	return nil

--- a/x/transfer/keeper/keeper.go
+++ b/x/transfer/keeper/keeper.go
@@ -43,7 +43,7 @@ func (k KeeperTransferWrapper) Transfer(goCtx context.Context, msg *wrappedtypes
 	}
 
 	// if the sender is a contract, lock fees.
-	// Because contracts are required to pay fees for the acknoledgements
+	// Because contracts are required to pay fees for the acknowledgements
 	if k.ContractManagerKeeper.HasContractInfo(ctx, senderAddr) {
 		if err := k.FeeKeeper.LockFees(ctx, senderAddr, feetypes.NewPacketID(msg.SourcePort, msg.SourceChannel, sequence), msg.Fee); err != nil {
 			return nil, sdkerrors.Wrapf(err, "failed to lock fees to pay for transfer msg: %v", msg)

--- a/x/transfer/module.go
+++ b/x/transfer/module.go
@@ -1,6 +1,8 @@
 package transfer
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -8,8 +10,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/ibc-go/v3/modules/apps/transfer"
 	"github.com/cosmos/ibc-go/v3/modules/apps/transfer/keeper"
+	"github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 
+	feetypes "github.com/neutron-org/neutron/x/feerefunder/types"
 	wrapkeeper "github.com/neutron-org/neutron/x/transfer/keeper"
 	neutrontypes "github.com/neutron-org/neutron/x/transfer/types"
 )
@@ -104,4 +108,40 @@ func (am AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 func (am AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 	neutrontypes.RegisterInterfaces(reg)
 	am.AppModuleBasic.RegisterInterfaces(reg)
+}
+
+// Name returns the capability module's name.
+func (am AppModule) Name() string {
+	return am.AppModuleBasic.Name()
+}
+
+// Deprecated: Route returns the capability module's message routing key.
+func (am AppModule) Route() sdk.Route {
+	return sdk.NewRoute(types.RouterKey, NewHandler(am.keeper))
+}
+
+func NewHandler(k wrapkeeper.KeeperTransferWrapper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
+		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+		switch msg := msg.(type) {
+		case *types.MsgTransfer:
+			neutronMsg := neutrontypes.MsgTransfer{
+				SourcePort:       msg.SourcePort,
+				SourceChannel:    msg.SourceChannel,
+				Token:            msg.Token,
+				Sender:           msg.Sender,
+				Receiver:         msg.Receiver,
+				TimeoutHeight:    msg.TimeoutHeight,
+				TimeoutTimestamp: msg.TimeoutTimestamp,
+				Fee:              feetypes.Fee{},
+			}
+			res, err := k.Transfer(sdk.WrapSDKContext(ctx), &neutronMsg)
+			return sdk.WrapServiceResult(ctx, res, err)
+
+		default:
+			errMsg := fmt.Sprintf("unrecognized %s message type: %T", types.ModuleName, msg)
+			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+		}
+	}
 }

--- a/x/transfer/types/expected_keepers.go
+++ b/x/transfer/types/expected_keepers.go
@@ -7,6 +7,7 @@ import (
 
 // ContractManagerKeeper defines the expected interface needed to add ack information about sudo failure.
 type ContractManagerKeeper interface {
+	HasContractInfo(ctx sdk.Context, contractAddress sdk.AccAddress) bool
 	AddContractFailure(ctx sdk.Context, address string, ackID uint64, ackType string)
 	SudoResponse(ctx sdk.Context, senderAddress sdk.AccAddress, request channeltypes.Packet, msg []byte) ([]byte, error)
 	SudoError(ctx sdk.Context, senderAddress sdk.AccAddress, request channeltypes.Packet, details string) ([]byte, error)


### PR DESCRIPTION
This PR fixes the problem when a a non-contract account cannot execute an IBC transfer msg.
IBC fees are not applied for non-contract transfers since there are no sudo happening during ACK/Timeout processing.

**MERGE WITH:**:
* https://github.com/neutron-org/neutron-integration-tests/pull/35