### PR TITLE
fix: feerefunder genesis validation

### DIFF
--- a/x/feerefunder/genesis_test.go
+++ b/x/feerefunder/genesis_test.go
@@ -12,16 +12,18 @@ import (
 	"github.com/neutron-org/neutron/x/feerefunder/types"
 )
 
+const TestContractAddressNeutron = "neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq"
+
 func TestGenesis(t *testing.T) {
 	genesisState := types.GenesisState{
 		Params: types.DefaultParams(),
-		FeeInfos: []types.FeeInfo{types.FeeInfo{
-			Payer:    "address",
-			PacketId: types.NewPacketID("port", "channel", 64),
+		FeeInfos: []types.FeeInfo{{
+			Payer:    TestContractAddressNeutron,
+			PacketId: types.NewPacketID("port", "channel-1", 64),
 			Fee: types.Fee{
-				RecvFee:    sdk.NewCoins(sdk.NewCoin("denom", sdk.NewInt(100))),
-				AckFee:     sdk.NewCoins(sdk.NewCoin("denom", sdk.NewInt(100))),
-				TimeoutFee: sdk.NewCoins(sdk.NewCoin("denom", sdk.NewInt(100))),
+				RecvFee:    sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(0))),
+				AckFee:     sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.AckFee.AmountOf(sdk.DefaultBondDenom).Int64()+1))),
+				TimeoutFee: sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.TimeoutFee.AmountOf(sdk.DefaultBondDenom).Int64()+1))),
 			},
 		}},
 	}

--- a/x/feerefunder/types/genesis.go
+++ b/x/feerefunder/types/genesis.go
@@ -1,11 +1,12 @@
 package types
 
 import (
-// this line is used by starport scaffolding # genesis/types/import
+	// this line is used by starport scaffolding # genesis/types/import
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 )
-
-// DefaultIndex is the default global index
-const DefaultIndex uint64 = 1
 
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
@@ -19,6 +20,29 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// this line is used by starport scaffolding # genesis/types/validate
-
+	for _, info := range gs.FeeInfos {
+		addr, err := sdk.AccAddressFromBech32(info.Payer)
+		if err != nil {
+			return err
+		}
+		if len(addr) != wasmtypes.ContractAddrLen {
+			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "Address is not a contract")
+		}
+		if err := host.PortIdentifierValidator(info.PacketId.PortId); err != nil {
+			return sdkerrors.Wrap(err, "invalid port ID")
+		}
+		if err := host.ChannelIdentifierValidator(info.PacketId.ChannelId); err != nil {
+			return sdkerrors.Wrap(err, "invalid channel ID")
+		}
+		if err := info.Fee.Validate(); err != nil {
+			return sdkerrors.Wrap(err, "")
+		}
+		if info.Fee.TimeoutFee.IsAllLT(gs.Params.MinFee.TimeoutFee) {
+			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided timeout fee is less than min governance set timeout fee: %v < %v", info.Fee.TimeoutFee, gs.Params.MinFee.TimeoutFee)
+		}
+		if info.Fee.AckFee.IsAllLT(gs.Params.MinFee.AckFee) {
+			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided ack fee is less than min governance set ack fee: %v < %v", info.Fee.AckFee, gs.Params.MinFee.AckFee)
+		}
+	}
 	return gs.Params.Validate()
 }

--- a/x/feerefunder/types/genesis.go
+++ b/x/feerefunder/types/genesis.go
@@ -26,22 +26,22 @@ func (gs GenesisState) Validate() error {
 			return err
 		}
 		if len(addr) != wasmtypes.ContractAddrLen {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "Address is not a contract")
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "fee payer address %v is not a contract", addr)
 		}
 		if err := host.PortIdentifierValidator(info.PacketId.PortId); err != nil {
-			return sdkerrors.Wrap(err, "invalid port ID")
+			return err
 		}
 		if err := host.ChannelIdentifierValidator(info.PacketId.ChannelId); err != nil {
-			return sdkerrors.Wrap(err, "invalid channel ID")
+			return err
 		}
 		if err := info.Fee.Validate(); err != nil {
-			return sdkerrors.Wrap(err, "")
+			return err
 		}
 		if info.Fee.TimeoutFee.IsAllLT(gs.Params.MinFee.TimeoutFee) {
-			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided timeout fee is less than min governance set timeout fee: %v < %v", info.Fee.TimeoutFee, gs.Params.MinFee.TimeoutFee)
+			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided timeout fee is less than min timeout fee: %v < %v", info.Fee.TimeoutFee, gs.Params.MinFee.TimeoutFee)
 		}
 		if info.Fee.AckFee.IsAllLT(gs.Params.MinFee.AckFee) {
-			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided ack fee is less than min governance set ack fee: %v < %v", info.Fee.AckFee, gs.Params.MinFee.AckFee)
+			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided ack fee is less than min ack fee: %v < %v", info.Fee.AckFee, gs.Params.MinFee.AckFee)
 		}
 	}
 	return gs.Params.Validate()

--- a/x/feerefunder/types/genesis.go
+++ b/x/feerefunder/types/genesis.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	// this line is used by starport scaffolding # genesis/types/import
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -23,20 +24,25 @@ func (gs GenesisState) Validate() error {
 	for _, info := range gs.FeeInfos {
 		addr, err := sdk.AccAddressFromBech32(info.Payer)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to parse the payer address %v: %v", info.Payer, err)
 		}
+
 		if len(addr) != wasmtypes.ContractAddrLen {
-			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "fee payer address %v is not a contract", addr)
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "fee payer address %v is not a contract", info.Payer)
 		}
+
 		if err := host.PortIdentifierValidator(info.PacketId.PortId); err != nil {
-			return err
+			return fmt.Errorf("port id %v is invalid: %v", info.PacketId.PortId, err)
 		}
+
 		if err := host.ChannelIdentifierValidator(info.PacketId.ChannelId); err != nil {
-			return err
+			return fmt.Errorf("channel id %v is invalid: %v", info.PacketId.PortId, err)
 		}
+
 		if err := info.Fee.Validate(); err != nil {
-			return err
+			return fmt.Errorf("invalid fees %v: %v", info.Fee, err)
 		}
+
 		if info.Fee.TimeoutFee.IsAllLT(gs.Params.MinFee.TimeoutFee) {
 			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided timeout fee is less than min timeout fee: %v < %v", info.Fee.TimeoutFee, gs.Params.MinFee.TimeoutFee)
 		}

--- a/x/feerefunder/types/genesis.go
+++ b/x/feerefunder/types/genesis.go
@@ -24,30 +24,23 @@ func (gs GenesisState) Validate() error {
 	for _, info := range gs.FeeInfos {
 		addr, err := sdk.AccAddressFromBech32(info.Payer)
 		if err != nil {
-			return fmt.Errorf("failed to parse the payer address %v: %v", info.Payer, err)
+			return fmt.Errorf("failed to parse the payer address %s: %w", info.Payer, err)
 		}
 
 		if len(addr) != wasmtypes.ContractAddrLen {
-			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "fee payer address %v is not a contract", info.Payer)
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "fee payer address %s is not a contract", info.Payer)
 		}
 
 		if err := host.PortIdentifierValidator(info.PacketId.PortId); err != nil {
-			return fmt.Errorf("port id %v is invalid: %v", info.PacketId.PortId, err)
+			return fmt.Errorf("port id %s is invalid: %w", info.PacketId.PortId, err)
 		}
 
 		if err := host.ChannelIdentifierValidator(info.PacketId.ChannelId); err != nil {
-			return fmt.Errorf("channel id %v is invalid: %v", info.PacketId.PortId, err)
+			return fmt.Errorf("channel id %s is invalid: %w", info.PacketId.PortId, err)
 		}
 
 		if err := info.Fee.Validate(); err != nil {
-			return fmt.Errorf("invalid fees %v: %v", info.Fee, err)
-		}
-
-		if info.Fee.TimeoutFee.IsAllLT(gs.Params.MinFee.TimeoutFee) {
-			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided timeout fee is less than min timeout fee: %v < %v", info.Fee.TimeoutFee, gs.Params.MinFee.TimeoutFee)
-		}
-		if info.Fee.AckFee.IsAllLT(gs.Params.MinFee.AckFee) {
-			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided ack fee is less than min ack fee: %v < %v", info.Fee.AckFee, gs.Params.MinFee.AckFee)
+			return fmt.Errorf("invalid fees %s: %w", info.Fee, err)
 		}
 	}
 	return gs.Params.Validate()

--- a/x/feerefunder/types/genesis_test.go
+++ b/x/feerefunder/types/genesis_test.go
@@ -25,20 +25,20 @@ func TestGenesisState_Validate(t *testing.T) {
 	validTimeoutFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.TimeoutFee.AmountOf(sdk.DefaultBondDenom).Int64()+1)))
 
 	invalidRecvFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1)))
-	invalidAckFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.AckFee.AmountOf(sdk.DefaultBondDenom).Int64()-1)))
-	invalidTimeoutFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.TimeoutFee.AmountOf(sdk.DefaultBondDenom).Int64()-1)))
 
 	validPacketId := types.NewPacketID("port", "channel-1", 64)
 
 	for _, tc := range []struct {
-		desc     string
-		genState *types.GenesisState
-		valid    bool
+		desc             string
+		genState         *types.GenesisState
+		valid            bool
+		expectedErrorMsg string
 	}{
 		{
-			desc:     "default is valid",
-			genState: types.DefaultGenesis(),
-			valid:    true,
+			desc:             "default is valid",
+			genState:         types.DefaultGenesis(),
+			valid:            true,
+			expectedErrorMsg: "",
 		},
 		{
 			desc: "valid genesis state",
@@ -54,7 +54,8 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				}},
 			},
-			valid: true,
+			valid:            true,
+			expectedErrorMsg: "",
 		},
 		{
 			desc: "invalid payer address",
@@ -70,7 +71,8 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				}},
 			},
-			valid: false,
+			valid:            false,
+			expectedErrorMsg: "failed to parse the payer address",
 		},
 		{
 			desc: "payer is not a contract",
@@ -86,7 +88,8 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				}},
 			},
-			valid: false,
+			valid:            false,
+			expectedErrorMsg: "is not a contract",
 		},
 		{
 			desc: "payer is from a wrong chain",
@@ -102,7 +105,8 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				}},
 			},
-			valid: false,
+			valid:            false,
+			expectedErrorMsg: "failed to parse the payer address",
 		},
 		{
 			desc: "invalid port",
@@ -118,7 +122,8 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				}},
 			},
-			valid: false,
+			valid:            false,
+			expectedErrorMsg: "port id",
 		},
 		{
 			desc: "invalid channel",
@@ -134,39 +139,8 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				}},
 			},
-			valid: false,
-		},
-		{
-			desc: "AckFee more than min",
-			genState: &types.GenesisState{
-				Params: types.DefaultParams(),
-				FeeInfos: []types.FeeInfo{{
-					Payer:    TestContractAddressNeutron,
-					PacketId: validPacketId,
-					Fee: types.Fee{
-						RecvFee:    validRecvFee,
-						AckFee:     invalidAckFee,
-						TimeoutFee: validTimeoutFee,
-					},
-				}},
-			},
-			valid: false,
-		},
-		{
-			desc: "TimeoutFee more than min",
-			genState: &types.GenesisState{
-				Params: types.DefaultParams(),
-				FeeInfos: []types.FeeInfo{{
-					Payer:    TestContractAddressNeutron,
-					PacketId: validPacketId,
-					Fee: types.Fee{
-						RecvFee:    validRecvFee,
-						AckFee:     validAckFee,
-						TimeoutFee: invalidTimeoutFee,
-					},
-				}},
-			},
-			valid: false,
+			valid:            false,
+			expectedErrorMsg: "channel id",
 		},
 		{
 			desc: "Recv fee non-zero",
@@ -182,7 +156,8 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 				}},
 			},
-			valid: false,
+			valid:            false,
+			expectedErrorMsg: "invalid fees",
 		},
 		{
 			desc: "Recv fee nil",
@@ -208,6 +183,7 @@ func TestGenesisState_Validate(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErrorMsg)
 			}
 		})
 	}

--- a/x/feerefunder/types/genesis_test.go
+++ b/x/feerefunder/types/genesis_test.go
@@ -41,7 +41,7 @@ func TestGenesisState_Validate(t *testing.T) {
 			valid:    true,
 		},
 		{
-			desc: "valid structure",
+			desc: "valid genesis state",
 			genState: &types.GenesisState{
 				Params: types.DefaultParams(),
 				FeeInfos: []types.FeeInfo{{

--- a/x/feerefunder/types/genesis_test.go
+++ b/x/feerefunder/types/genesis_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/neutron-org/neutron/x/feerefunder/types"
 )
 
-const TestAddressNeutron = "cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw"
+const TestAddressNeutron = "neutron13xvjxhkkxxhztcugr6weyt76eedj5ucpt4xluv"
 const TestContractAddressJuno = "juno10h0hc64jv006rr8qy0zhlu4jsxct8qwa0vtaleayh0ujz0zynf2s2r7v8q"
 const TestContractAddressNeutron = "neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq"
 

--- a/x/feerefunder/types/genesis_test.go
+++ b/x/feerefunder/types/genesis_test.go
@@ -3,11 +3,33 @@ package types_test
 import (
 	"testing"
 
-	"github.com/neutron-org/neutron/x/feerefunder/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/neutron-org/neutron/app"
+
 	"github.com/stretchr/testify/require"
+
+	"github.com/neutron-org/neutron/x/feerefunder/types"
 )
 
+const TestAddressNeutron = "cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw"
+const TestContractAddressJuno = "juno10h0hc64jv006rr8qy0zhlu4jsxct8qwa0vtaleayh0ujz0zynf2s2r7v8q"
+const TestContractAddressNeutron = "neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq"
+
 func TestGenesisState_Validate(t *testing.T) {
+	cfg := app.GetDefaultConfig()
+	cfg.Seal()
+
+	validRecvFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(0)))
+	validAckFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.AckFee.AmountOf(sdk.DefaultBondDenom).Int64()+1)))
+	validTimeoutFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.TimeoutFee.AmountOf(sdk.DefaultBondDenom).Int64()+1)))
+
+	invalidRecvFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1)))
+	invalidAckFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.AckFee.AmountOf(sdk.DefaultBondDenom).Int64()-1)))
+	invalidTimeoutFee := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(types.DefaultFees.TimeoutFee.AmountOf(sdk.DefaultBondDenom).Int64()-1)))
+
+	validPacketId := types.NewPacketID("port", "channel-1", 64)
+
 	for _, tc := range []struct {
 		desc     string
 		genState *types.GenesisState
@@ -19,10 +41,162 @@ func TestGenesisState_Validate(t *testing.T) {
 			valid:    true,
 		},
 		{
-			desc:     "valid genesis state",
+			desc: "valid structure",
 			genState: &types.GenesisState{
-
-				// this line is used by starport scaffolding # types/genesis/validField
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressNeutron,
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: true,
+		},
+		{
+			desc: "invalid payer address",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    "address",
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "payer is not a contract",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestAddressNeutron,
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "payer is from a wrong chain",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressJuno,
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "invalid port",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressNeutron,
+					PacketId: types.NewPacketID("*", "channel", 64),
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "invalid channel",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressNeutron,
+					PacketId: types.NewPacketID("port", "*", 64),
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "AckFee more than min",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressNeutron,
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     invalidAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "TimeoutFee more than min",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressNeutron,
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    validRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: invalidTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "Recv fee non-zero",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressNeutron,
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    invalidRecvFee,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
+			},
+			valid: false,
+		},
+		{
+			desc: "Recv fee nil",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				FeeInfos: []types.FeeInfo{{
+					Payer:    TestContractAddressNeutron,
+					PacketId: validPacketId,
+					Fee: types.Fee{
+						RecvFee:    nil,
+						AckFee:     validAckFee,
+						TimeoutFee: validTimeoutFee,
+					},
+				}},
 			},
 			valid: true,
 		},

--- a/x/feerefunder/types/params.go
+++ b/x/feerefunder/types/params.go
@@ -41,7 +41,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 
 // Validate validates the set of params
 func (p Params) Validate() error {
-	return validateFee(p.MinFee)
+	return p.MinFee.Validate()
 }
 
 // String implements the Stringer interface.

--- a/x/feerefunder/types/params.go
+++ b/x/feerefunder/types/params.go
@@ -13,7 +13,7 @@ var _ paramtypes.ParamSet = (*Params)(nil)
 var (
 	KeyFees     = []byte("FEES")
 	DefaultFees = Fee{
-		RecvFee:    sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1000))),
+		RecvFee:    nil,
 		AckFee:     sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1000))),
 		TimeoutFee: sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1000))),
 	}
@@ -41,7 +41,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 
 // Validate validates the set of params
 func (p Params) Validate() error {
-	return nil
+	return validateFee(p.MinFee)
 }
 
 // String implements the Stringer interface.
@@ -56,9 +56,5 @@ func validateFee(i interface{}) error {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 
-	if v.RecvFee.IsZero() || v.AckFee.IsZero() || v.TimeoutFee.IsZero() {
-		return fmt.Errorf("feerefunder can't be zero: %s", v)
-	}
-
-	return nil
+	return v.Validate()
 }


### PR DESCRIPTION
According to the audit report:

> Lack of validation for the GenesisState of the feerefunder module
> Severity: Minor
> In `neutron:x/feerefunder/types/genesis.go:20`, the Validate function is not validating FeeInfos and Params parameters. 
> It should ensure that Payer is a correct address and that both PacketId and Fee structs are well constructed.
> Also, the Validate function for Params in `neutron:x/feerefunder/types/params.go:43-45` is not implemented and it is
always returning nil.
> Recommendation
> We recommend implementing validation for the GenesisState of the feerefunder module

Changes:
1. Added validation of the `GenesisState` structure. Everything is basic-validated but Sequence (since it is just a number)
2. Added unit tests to check if validation works properly
3. Fixed an issue with providing the non-zero minimum `RecvFee`
4. `RecvFee` is provided as `nil` to be compatible with the `TestGenesis` test since even if we provide an empty slice as `RecvFee`, `ExportGenesis` gets `RecvFee` as nil and it breaks the tests (while being semantically equivalent). This issue needs to be addressed further.

How to test it:
Use unit tests (`make test`) and regular integration tests pipeline to test the code. No changes in external components were made.