### PR TITLE
(NTRN-275) fix: limitation of Failures query 

### DIFF
--- a/x/contractmanager/keeper/grpc_query_failure.go
+++ b/x/contractmanager/keeper/grpc_query_failure.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var LimitCap uint64 = 100
+var FailuresQueryMaxLimit uint64 = query.DefaultLimit
 
 func (k Keeper) Failures(c context.Context, req *types.QueryFailuresRequest) (*types.QueryFailuresResponse, error) {
 	return k.AddressFailures(c, req)
@@ -23,8 +23,8 @@ func (k Keeper) AddressFailures(c context.Context, req *types.QueryFailuresReque
 	}
 
 	pagination := req.GetPagination()
-	if pagination != nil && pagination.Limit > LimitCap {
-		return nil, status.Errorf(codes.InvalidArgument, "limit %v is too high, should be less or equal %v", pagination.Limit, LimitCap)
+	if pagination != nil && pagination.Limit > FailuresQueryMaxLimit {
+		return nil, status.Errorf(codes.InvalidArgument, "limit %d is too high, should be less or equal %d", pagination.Limit, FailuresQueryMaxLimit)
 	}
 
 	var failures []types.Failure

--- a/x/contractmanager/keeper/grpc_query_failure.go
+++ b/x/contractmanager/keeper/grpc_query_failure.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var FailuresQueryMaxLimit uint64 = query.DefaultLimit
+const FailuresQueryMaxLimit uint64 = query.DefaultLimit
 
 func (k Keeper) Failures(c context.Context, req *types.QueryFailuresRequest) (*types.QueryFailuresResponse, error) {
 	return k.AddressFailures(c, req)

--- a/x/contractmanager/keeper/grpc_query_failure.go
+++ b/x/contractmanager/keeper/grpc_query_failure.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var LimitCap uint64 = 100
+
 func (k Keeper) Failures(c context.Context, req *types.QueryFailuresRequest) (*types.QueryFailuresResponse, error) {
 	return k.AddressFailures(c, req)
 }
@@ -18,6 +20,11 @@ func (k Keeper) Failures(c context.Context, req *types.QueryFailuresRequest) (*t
 func (k Keeper) AddressFailures(c context.Context, req *types.QueryFailuresRequest) (*types.QueryFailuresResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	pagination := req.GetPagination()
+	if pagination != nil && pagination.Limit > LimitCap {
+		return nil, status.Errorf(codes.InvalidArgument, "limit %v is too high, should be less or equal %v", pagination.Limit, LimitCap)
 	}
 
 	var failures []types.Failure

--- a/x/contractmanager/keeper/grpc_query_failure.go
+++ b/x/contractmanager/keeper/grpc_query_failure.go
@@ -24,7 +24,7 @@ func (k Keeper) AddressFailures(c context.Context, req *types.QueryFailuresReque
 
 	pagination := req.GetPagination()
 	if pagination != nil && pagination.Limit > FailuresQueryMaxLimit {
-		return nil, status.Errorf(codes.InvalidArgument, "limit %d is too high, should be less or equal %d", pagination.Limit, FailuresQueryMaxLimit)
+		return nil, status.Errorf(codes.InvalidArgument, "limit is more than maximum allowed (%d > %d)", pagination.Limit, FailuresQueryMaxLimit)
 	}
 
 	var failures []types.Failure

--- a/x/contractmanager/keeper/grpc_query_failure_test.go
+++ b/x/contractmanager/keeper/grpc_query_failure_test.go
@@ -130,7 +130,7 @@ func TestFailureQueryPaginated(t *testing.T) {
 	})
 	t.Run("More than limit", func(t *testing.T) {
 		_, err := keeper.Failures(wctx, request(nil, 0, math.MaxUint64, true))
-		require.Error(t, err)
+		require.ErrorContains(t, err, "is too high, should be less or equal")
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := keeper.Failures(wctx, nil)

--- a/x/contractmanager/keeper/grpc_query_failure_test.go
+++ b/x/contractmanager/keeper/grpc_query_failure_test.go
@@ -130,7 +130,7 @@ func TestFailureQueryPaginated(t *testing.T) {
 	})
 	t.Run("More than limit", func(t *testing.T) {
 		_, err := keeper.Failures(wctx, request(nil, 0, math.MaxUint64, true))
-		require.ErrorContains(t, err, "is too high, should be less or equal")
+		require.ErrorContains(t, err, "limit is more than maximum allowed")
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := keeper.Failures(wctx, nil)

--- a/x/contractmanager/keeper/grpc_query_failure_test.go
+++ b/x/contractmanager/keeper/grpc_query_failure_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
@@ -126,6 +127,10 @@ func TestFailureQueryPaginated(t *testing.T) {
 			nullify.Fill(flattenItems),
 			nullify.Fill(resp.Failures),
 		)
+	})
+	t.Run("More than limit", func(t *testing.T) {
+		_, err := keeper.Failures(wctx, request(nil, 0, math.MaxUint64, true))
+		require.Error(t, err)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := keeper.Failures(wctx, nil)

--- a/x/contractmanager/keeper/grpc_query_failure_test.go
+++ b/x/contractmanager/keeper/grpc_query_failure_test.go
@@ -1,7 +1,7 @@
 package keeper_test
 
 import (
-	"math"
+	keeper_package "github.com/neutron-org/neutron/x/contractmanager/keeper"
 	"strconv"
 	"testing"
 
@@ -129,7 +129,7 @@ func TestFailureQueryPaginated(t *testing.T) {
 		)
 	})
 	t.Run("More than limit", func(t *testing.T) {
-		_, err := keeper.Failures(wctx, request(nil, 0, math.MaxUint64, true))
+		_, err := keeper.Failures(wctx, request(nil, 0, keeper_package.FailuresQueryMaxLimit+1, true))
 		require.ErrorContains(t, err, "limit is more than maximum allowed")
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {

--- a/x/contractmanager/keeper/grpc_query_failure_test.go
+++ b/x/contractmanager/keeper/grpc_query_failure_test.go
@@ -128,7 +128,7 @@ func TestFailureQueryPaginated(t *testing.T) {
 			nullify.Fill(resp.Failures),
 		)
 	})
-	t.Run("More than limit", func(t *testing.T) {
+	t.Run("MoreThanLimit", func(t *testing.T) {
 		_, err := keeper.Failures(wctx, request(nil, 0, keeper_package.FailuresQueryMaxLimit+1, true))
 		require.ErrorContains(t, err, "limit is more than maximum allowed")
 	})


### PR DESCRIPTION
According to the audit report, there is an ability to spam RPC by setting up the big/max `limit` parameter for pagination of Failures query.

This PR implements a simple fix by setting the cap for the `limit` parameter to `DefaultLimit` (100).  [(NTRN-275)](https://p2pvalidator.atlassian.net/browse/NTRN-275)

Changes:
1. Cap for the `limit` parameter is added.
2. Added unit test for checking max limit.

How to test the code:
Use unit tests (`make test`) and integration tests from [this PR](https://github.com/neutron-org/neutron-integration-tests/pull/44) to test the code. No changes in external components were made.