### PR TITLE
Feature: emit feerefunder's events

### DIFF
--- a/x/feerefunder/keeper/keeper.go
+++ b/x/feerefunder/keeper/keeper.go
@@ -74,15 +74,15 @@ func (k Keeper) LockFees(ctx sdk.Context, payer sdk.AccAddress, packetID types.P
 	k.StoreFeeInfo(ctx, feeInfo)
 
 	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, payer, types.ModuleName, fee.Total()); err != nil {
-		return err
+		return sdkerrors.Wrapf(err, "failed to send coins during fees locking")
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeLockFees,
 			sdk.NewAttribute(types.AttributeKeyPayer, payer.String()),
-			sdk.NewAttribute(types.AttributeKeyPortId, packetID.PortId),
-			sdk.NewAttribute(types.AttributeKeyChannelId, packetID.ChannelId),
+			sdk.NewAttribute(types.AttributeKeyPortID, packetID.PortId),
+			sdk.NewAttribute(types.AttributeKeyChannelID, packetID.ChannelId),
 			sdk.NewAttribute(types.AttributeKeySequence, strconv.FormatUint(packetID.Sequence, 10)),
 		),
 		sdk.NewEvent(
@@ -118,8 +118,8 @@ func (k Keeper) DistributeAcknowledgementFee(ctx sdk.Context, receiver sdk.AccAd
 		sdk.NewEvent(
 			types.EventTypeDistributeAcknowledgementFee,
 			sdk.NewAttribute(types.AttributeKeyReceiver, receiver.String()),
-			sdk.NewAttribute(types.AttributeKeyPortId, packetID.PortId),
-			sdk.NewAttribute(types.AttributeKeyChannelId, packetID.ChannelId),
+			sdk.NewAttribute(types.AttributeKeyPortID, packetID.PortId),
+			sdk.NewAttribute(types.AttributeKeyChannelID, packetID.ChannelId),
 			sdk.NewAttribute(types.AttributeKeySequence, strconv.FormatUint(packetID.Sequence, 10)),
 		),
 		sdk.NewEvent(
@@ -155,8 +155,8 @@ func (k Keeper) DistributeTimeoutFee(ctx sdk.Context, receiver sdk.AccAddress, p
 		sdk.NewEvent(
 			types.EventTypeDistributeTimeoutFee,
 			sdk.NewAttribute(types.AttributeKeyReceiver, receiver.String()),
-			sdk.NewAttribute(types.AttributeKeyPortId, packetID.PortId),
-			sdk.NewAttribute(types.AttributeKeyChannelId, packetID.ChannelId),
+			sdk.NewAttribute(types.AttributeKeyPortID, packetID.PortId),
+			sdk.NewAttribute(types.AttributeKeyChannelID, packetID.ChannelId),
 			sdk.NewAttribute(types.AttributeKeySequence, strconv.FormatUint(packetID.Sequence, 10)),
 		),
 		sdk.NewEvent(

--- a/x/feerefunder/types/events.go
+++ b/x/feerefunder/types/events.go
@@ -4,7 +4,7 @@ package types
 const (
 	EventTypeDistributeAcknowledgementFee = "distribute_ack_fee"
 	EventTypeDistributeTimeoutFee         = "distribute_timeout_fee"
-	EventTypeLockFees                     = "distribute_lock_fees"
+	EventTypeLockFees                     = "lock_fees"
 
 	AttributeKeyReceiver  = "receiver"
 	AttributeKeyChannelID = "channel_id"

--- a/x/feerefunder/types/events.go
+++ b/x/feerefunder/types/events.go
@@ -1,0 +1,14 @@
+package types
+
+// feerefunder module event types
+const (
+	EventTypeDistributeAcknowledgementFee = "distribute_ack_fee"
+	EventTypeDistributeTimeoutFee         = "distribute_timeout_fee"
+	EventTypeLockFees                     = "distribute_lock_fees"
+
+	AttributeKeyReceiver  = "receiver"
+	AttributeKeyChannelId = "channel_id"
+	AttributeKeyPortId    = "port_id"
+	AttributeKeySequence  = "sequence"
+	AttributeKeyPayer     = "payer"
+)

--- a/x/feerefunder/types/events.go
+++ b/x/feerefunder/types/events.go
@@ -7,8 +7,8 @@ const (
 	EventTypeLockFees                     = "distribute_lock_fees"
 
 	AttributeKeyReceiver  = "receiver"
-	AttributeKeyChannelId = "channel_id"
-	AttributeKeyPortId    = "port_id"
+	AttributeKeyChannelID = "channel_id"
+	AttributeKeyPortID    = "port_id"
 	AttributeKeySequence  = "sequence"
 	AttributeKeyPayer     = "payer"
 )


### PR DESCRIPTION
According to the audit report, we emit an event during AcknowlegementFee Distribution and emit nothing during TimeoutFee Distribution. However, even in the AcknowlegementFee case event emotion done wrong. This PR is to add proper events emotion for feerefunder module.  [(NTRN-275)](https://p2pvalidator.atlassian.net/browse/NTRN-275)

Changes:
1. Added events emotion for fees lock and distribution
