### PR TITLE
Fix: proper fees checking

### DIFF
--- a/x/feerefunder/keeper/export_test.go
+++ b/x/feerefunder/keeper/export_test.go
@@ -1,0 +1,10 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/neutron-org/neutron/x/feerefunder/types"
+)
+
+func (k Keeper) CheckFees(ctx sdk.Context, fees types.Fee) error {
+	return k.checkFees(ctx, fees)
+}

--- a/x/feerefunder/keeper/keeper.go
+++ b/x/feerefunder/keeper/keeper.go
@@ -169,11 +169,11 @@ func (k Keeper) removeFeeInfo(ctx sdk.Context, packetID types.PacketID) {
 func (k Keeper) checkFees(ctx sdk.Context, fees types.Fee) error {
 	params := k.GetParams(ctx)
 
-	if fees.TimeoutFee.IsAllLT(params.MinFee.TimeoutFee) {
+	if !fees.TimeoutFee.IsAnyGTE(params.MinFee.TimeoutFee) {
 		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided timeout fee is less than min governance set timeout fee: %v < %v", fees.TimeoutFee, params.MinFee.TimeoutFee)
 	}
 
-	if fees.AckFee.IsAllLT(params.MinFee.AckFee) {
+	if !fees.AckFee.IsAnyGTE(params.MinFee.AckFee) {
 		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "provided ack fee is less than min governance set ack fee: %v < %v", fees.AckFee, params.MinFee.AckFee)
 	}
 

--- a/x/feerefunder/keeper/keeper_test.go
+++ b/x/feerefunder/keeper/keeper_test.go
@@ -1,50 +1,18 @@
-package keeper
+package keeper_test
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/store"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
-	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	tmdb "github.com/tendermint/tm-db"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	testutil_keeper "github.com/neutron-org/neutron/testutil/keeper"
+	"github.com/pkg/errors"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/neutron-org/neutron/x/feerefunder/types"
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/libs/log"
 )
 
 func TestKeeperCheckFees(t *testing.T) {
-	storeKey := sdk.NewKVStoreKey(types.StoreKey)
-	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
-
-	db := tmdb.NewMemDB()
-	stateStore := store.NewCommitMultiStore(db)
-	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
-	stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
-	require.NoError(t, stateStore.LoadLatestVersion())
-
-	registry := codectypes.NewInterfaceRegistry()
-	cdc := codec.NewProtoCodec(registry)
-
-	paramsSubspace := typesparams.NewSubspace(cdc,
-		types.Amino,
-		storeKey,
-		memStoreKey,
-		"FeeParams",
-	)
-	k := NewKeeper(
-		cdc,
-		storeKey,
-		memStoreKey,
-		paramsSubspace,
-		nil,
-		nil,
-	)
-
-	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	k, ctx := testutil_keeper.FeeKeeper(t)
 
 	k.SetParams(ctx, types.Params{
 		MinFee: types.Fee{
@@ -106,11 +74,12 @@ func TestKeeperCheckFees(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := k.checkFees(ctx, *tc.fees)
+			err := k.CheckFees(ctx, *tc.fees)
 			if tc.valid {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
+				require.IsType(t, errors.WithStack(sdkerrors.ErrInsufficientFee), errors.Unwrap(err))
 			}
 		})
 	}

--- a/x/feerefunder/keeper/keeper_test.go
+++ b/x/feerefunder/keeper/keeper_test.go
@@ -28,7 +28,7 @@ func TestKeeperCheckFees(t *testing.T) {
 		valid bool
 	}{
 		{
-			desc: "single proper denom but insufficient",
+			desc: "SingleProperDenomInsufficient",
 			fees: &types.Fee{
 				RecvFee:    nil,
 				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(1))),
@@ -37,7 +37,7 @@ func TestKeeperCheckFees(t *testing.T) {
 			valid: false,
 		},
 		{
-			desc: "single denom sufficient amount",
+			desc: "SingleDenomSufficient",
 			fees: &types.Fee{
 				RecvFee:    nil,
 				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101))),
@@ -46,7 +46,7 @@ func TestKeeperCheckFees(t *testing.T) {
 			valid: true,
 		},
 		{
-			desc: "multiple denoms, both are proper, only one enough",
+			desc: "MultipleDenomsOneIsEnough",
 			fees: &types.Fee{
 				RecvFee:    nil,
 				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101)), sdk.NewCoin("denom2", sdk.NewInt(1))),
@@ -55,7 +55,7 @@ func TestKeeperCheckFees(t *testing.T) {
 			valid: true,
 		},
 		{
-			desc: "no proper denom",
+			desc: "NoProperDenom",
 			fees: &types.Fee{
 				RecvFee:    nil,
 				AckFee:     sdk.NewCoins(sdk.NewCoin("denom3", sdk.NewInt(1))),
@@ -64,7 +64,7 @@ func TestKeeperCheckFees(t *testing.T) {
 			valid: false,
 		},
 		{
-			desc: "proper denom plus random one",
+			desc: "ProperDenomPlusRandomOne",
 			fees: &types.Fee{
 				RecvFee:    nil,
 				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101)), sdk.NewCoin("denom3", sdk.NewInt(1))),

--- a/x/feerefunder/keeper/keeper_test.go
+++ b/x/feerefunder/keeper/keeper_test.go
@@ -1,0 +1,117 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/neutron-org/neutron/x/feerefunder/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestKeeperCheckFees(t *testing.T) {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+
+	paramsSubspace := typesparams.NewSubspace(cdc,
+		types.Amino,
+		storeKey,
+		memStoreKey,
+		"FeeParams",
+	)
+	k := NewKeeper(
+		cdc,
+		storeKey,
+		memStoreKey,
+		paramsSubspace,
+		nil,
+		nil,
+	)
+
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+
+	k.SetParams(ctx, types.Params{
+		MinFee: types.Fee{
+			RecvFee:    nil,
+			AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(100)), sdk.NewCoin("denom2", sdk.NewInt(100))),
+			TimeoutFee: sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(100)), sdk.NewCoin("denom2", sdk.NewInt(100))),
+		},
+	})
+
+	for _, tc := range []struct {
+		desc  string
+		fees  *types.Fee
+		valid bool
+	}{
+		{
+			desc: "single proper denom but insufficient",
+			fees: &types.Fee{
+				RecvFee:    nil,
+				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(1))),
+				TimeoutFee: sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(1))),
+			},
+			valid: false,
+		},
+		{
+			desc: "single denom sufficient amount",
+			fees: &types.Fee{
+				RecvFee:    nil,
+				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101))),
+				TimeoutFee: sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101))),
+			},
+			valid: true,
+		},
+		{
+			desc: "multiple denoms, both are proper, only one enough",
+			fees: &types.Fee{
+				RecvFee:    nil,
+				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101)), sdk.NewCoin("denom2", sdk.NewInt(1))),
+				TimeoutFee: sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101)), sdk.NewCoin("denom2", sdk.NewInt(1))),
+			},
+			valid: true,
+		},
+		{
+			desc: "no proper denom",
+			fees: &types.Fee{
+				RecvFee:    nil,
+				AckFee:     sdk.NewCoins(sdk.NewCoin("denom3", sdk.NewInt(1))),
+				TimeoutFee: sdk.NewCoins(sdk.NewCoin("denom3", sdk.NewInt(1))),
+			},
+			valid: false,
+		},
+		{
+			desc: "proper denom plus random one",
+			fees: &types.Fee{
+				RecvFee:    nil,
+				AckFee:     sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101)), sdk.NewCoin("denom3", sdk.NewInt(1))),
+				TimeoutFee: sdk.NewCoins(sdk.NewCoin("denom1", sdk.NewInt(101)), sdk.NewCoin("denom3", sdk.NewInt(1))),
+			},
+			valid: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := k.checkFees(ctx, *tc.fees)
+			if tc.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
According to the audit report, fees are not checked properly and a fee with single coin that is not in the `MinFees` can bypass the check. This PR is to solve this issue. [(NTRN-275)](https://p2pvalidator.atlassian.net/browse/NTRN-275)

Integration tests are [here](https://github.com/neutron-org/neutron-integration-tests/pull/43).

P.S. I'm still a bit in doubt about the `export_test.go` hack to export private `checkFees` method for unit tests, any recommendations in this regard are very welcome.