### PR TITLE
fix: missing deposit array into registered query #NTRN-263

### DIFF
--- a/wasmbinding/bindings/query.go
+++ b/wasmbinding/bindings/query.go
@@ -75,7 +75,7 @@ type RegisteredQuery struct {
 	// The remote chain last block height when the query result was updated.
 	LastSubmittedResultRemoteHeight uint64 `json:"last_submitted_result_remote_height"`
 	// Amount of coins deposited for the query.
-	QueryDeposit sdktypes.Coins `json:"query_deposit"`
+	Deposit sdktypes.Coins `json:"deposit"`
 	// Timeout before query becomes available for everybody to remove.
 	SubmitTimeout uint64 `json:"submit_timeout"`
 }

--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -95,5 +95,6 @@ func mapGRPCRegisteredQueryToWasmBindings(grpcQuery types.RegisteredQuery) bindi
 		UpdatePeriod:                    grpcQuery.GetUpdatePeriod(),
 		LastSubmittedResultLocalHeight:  grpcQuery.GetLastSubmittedResultLocalHeight(),
 		LastSubmittedResultRemoteHeight: grpcQuery.GetLastSubmittedResultRemoteHeight(),
+		Deposit:                         grpcQuery.GetDeposit(),
 	}
 }


### PR DESCRIPTION
So seems some strange shit happened and we messed with the field names and so on
To test it 
1. run cosmopark
2. get bash script from the task https://p2pvalidator.atlassian.net/browse/NTRN-263
3. copy interchain_queries contract and the bash script into it
4. apt-get update && apt-get install jq -y
5. run bash script 