### PR TITLE
Initialize auth before ibc transfer

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -619,8 +619,8 @@ func New(
 	// can do so safely.
 	app.mm.SetOrderInitGenesis(
 		capabilitytypes.ModuleName,
-		ibctransfertypes.ModuleName,
 		authtypes.ModuleName,
+		ibctransfertypes.ModuleName,
 		authz.ModuleName,
 		banktypes.ModuleName,
 		vestingtypes.ModuleName,


### PR DESCRIPTION
Fixes an issue solved previously in the dummy consumer from the ICS repo, where the auth module needs to be initialized before the ibc transfer module to allow ibctesting code to work properly 

See https://github.com/cosmos/interchain-security/issues/151 and https://github.com/cosmos/interchain-security/pull/495