### PR TITLE
feat: remove processed tx hashes on remove TX InterchainQuery

### DIFF
--- a/x/interchainqueries/keeper/keeper_test.go
+++ b/x/interchainqueries/keeper/keeper_test.go
@@ -429,7 +429,9 @@ func (suite *KeeperTestSuite) TestRemoveInterchainQuery() {
 					UpdatePeriod:       1,
 					Sender:             "",
 				}
-				for i := 1; i <= 10000; i++ {
+				hashesCount := 10000
+				txQueryHashes = make([][]byte, 0, hashesCount)
+				for i := 1; i <= hashesCount; i++ {
 					txQueryHashes = append(txQueryHashes, []byte(fmt.Sprintf("txhash_%d", i)))
 				}
 			},

--- a/x/interchainqueries/keeper/msg_server.go
+++ b/x/interchainqueries/keeper/msg_server.go
@@ -102,17 +102,9 @@ func (k msgServer) RemoveInterchainQuery(goCtx context.Context, msg *types.MsgRe
 		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "authorization failed")
 	}
 
-	k.RemoveQueryByID(ctx, query.Id)
+	k.RemoveQuery(ctx, query)
 	k.MustPayOutDeposit(ctx, query.Deposit, msg.GetSigners()[0])
-	if types.InterchainQueryType(query.GetQueryType()).IsKV() {
-		k.removeQueryResultByID(ctx, query.Id)
-	}
-
 	ctx.EventManager().EmitEvents(getEventsQueryRemoved(query))
-
-	// NOTE: there is no easy way to remove the list of processed transactions
-	// without knowing transaction hashes.
-
 	return &types.MsgRemoveInterchainQueryResponse{}, nil
 }
 

--- a/x/interchainqueries/keeper/process_block_results.go
+++ b/x/interchainqueries/keeper/process_block_results.go
@@ -131,28 +131,28 @@ func (k Keeper) ProcessBlock(ctx sdk.Context, queryOwner sdk.AccAddress, queryID
 		txData = tx.GetData()
 		txHash = tmtypes.Tx(txData).Hash()
 	)
-	if !k.CheckTransactionIsAlreadyProcessed(ctx, queryID, txHash) {
-		// Check that cryptography is O.K. (tx is included in the block, tx was executed successfully)
-		if err = k.transactionVerifier.VerifyTransaction(tmHeader, tmNextHeader, tx); err != nil {
-			ctx.Logger().Debug("ProcessBlock: failed to verifyTransaction",
-				"error", err, "query_id", queryID, "tx_hash", hex.EncodeToString(txHash))
-			return sdkerrors.Wrapf(types.ErrInternal, "failed to verifyTransaction %s: %v", hex.EncodeToString(txHash), err)
-		}
-
-		// Let the query owner contract process the query result.
-		if _, err := k.contractManagerKeeper.SudoTxQueryResult(ctx, queryOwner, queryID, tmHeader.Header.Height, txData); err != nil {
-			ctx.Logger().Debug("ProcessBlock: failed to SudoTxQueryResult",
-				"error", err, "query_id", queryID, "tx_hash", hex.EncodeToString(txHash))
-			return sdkerrors.Wrapf(err, "contract %s rejected transaction query result (tx_hash: %s)",
-				queryOwner, hex.EncodeToString(txHash))
-		}
-
-		k.SaveTransactionAsProcessed(ctx, queryID, txHash)
-	} else {
+	if k.CheckTransactionIsAlreadyProcessed(ctx, queryID, txHash) {
 		ctx.Logger().Debug("ProcessBlock: transaction was already submitted",
 			"query_id", queryID, "tx_hash", hex.EncodeToString(txHash))
+		return nil
 	}
 
+	// Check that cryptography is O.K. (tx is included in the block, tx was executed successfully)
+	if err = k.transactionVerifier.VerifyTransaction(tmHeader, tmNextHeader, tx); err != nil {
+		ctx.Logger().Debug("ProcessBlock: failed to verifyTransaction",
+			"error", err, "query_id", queryID, "tx_hash", hex.EncodeToString(txHash))
+		return sdkerrors.Wrapf(types.ErrInternal, "failed to verifyTransaction %s: %v", hex.EncodeToString(txHash), err)
+	}
+
+	// Let the query owner contract process the query result.
+	if _, err := k.contractManagerKeeper.SudoTxQueryResult(ctx, queryOwner, queryID, tmHeader.Header.Height, txData); err != nil {
+		ctx.Logger().Debug("ProcessBlock: failed to SudoTxQueryResult",
+			"error", err, "query_id", queryID, "tx_hash", hex.EncodeToString(txHash))
+		return sdkerrors.Wrapf(err, "contract %s rejected transaction query result (tx_hash: %s)",
+			queryOwner, hex.EncodeToString(txHash))
+	}
+
+	k.SaveTransactionAsProcessed(ctx, queryID, txHash)
 	return nil
 }
 


### PR DESCRIPTION
**task:** https://p2pvalidator.atlassian.net/browse/NTRN-349

**this PR:**
- adds relative processed TX hashes removal on removal of a TX interchain query;
- makes the above-mentioned calls partially refunded: only interaction with the storage is refunded, more details about refunding below;
- prettifies ProcessBlock method.

**refund details:**
before refund is added:
- small tx query removal cost: 13892;
- large tx query removal cost (10,000 tx hashes): 10908412;
- kv query removal cost: 12661.

after refund is added:
- small tx query removal cost: 10649;
- large tx query removal cost (10,000 tx hashes): 10649;
- kv query removal cost: 10661.

**tests run:**
https://github.com/neutron-org/neutron-tests/actions/runs/4164639065