### PR TITLE
feat: optimize SubmitQueryResult NTRN-353

### DIFF
--- a/wasmbinding/test/custom_query_test.go
+++ b/wasmbinding/test/custom_query_test.go
@@ -39,7 +39,7 @@ func (suite *CustomQuerierTestSuite) TestInterchainQueryResult() {
 	clientKey := host.FullClientStateKey(suite.Path.EndpointB.ClientID)
 	lastID := neutron.InterchainQueriesKeeper.GetLastRegisteredQueryKey(ctx) + 1
 	neutron.InterchainQueriesKeeper.SetLastRegisteredQueryKey(ctx, lastID)
-	registeredQuery := icqtypes.RegisteredQuery{
+	registeredQuery := &icqtypes.RegisteredQuery{
 		Id: lastID,
 		Keys: []*icqtypes.KVKey{
 			{Path: host.StoreKey, Key: clientKey},

--- a/x/interchainqueries/genesis.go
+++ b/x/interchainqueries/genesis.go
@@ -19,7 +19,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	// Set all registered queries
 	for _, elem := range genState.RegisteredQueries {
 		k.SetLastRegisteredQueryKey(ctx, elem.Id)
-		if err := k.SaveQuery(ctx, *elem); err != nil {
+		if err := k.SaveQuery(ctx, elem); err != nil {
 			panic(err)
 		}
 

--- a/x/interchainqueries/keeper/grpc_query_test.go
+++ b/x/interchainqueries/keeper/grpc_query_test.go
@@ -414,7 +414,7 @@ func (suite *KeeperTestSuite) TestRegisteredQueries() {
 			suite.SetupTest()
 
 			for _, q := range tt.registeredQueries {
-				suite.NoError(suite.GetNeutronZoneApp(suite.ChainA).InterchainQueriesKeeper.SaveQuery(suite.ChainA.GetContext(), q))
+				suite.NoError(suite.GetNeutronZoneApp(suite.ChainA).InterchainQueriesKeeper.SaveQuery(suite.ChainA.GetContext(), &q))
 			}
 
 			resp, err := suite.GetNeutronZoneApp(suite.ChainA).InterchainQueriesKeeper.RegisteredQueries(sdk.WrapSDKContext(suite.ChainA.GetContext()), tt.req)

--- a/x/interchainqueries/keeper/keeper.go
+++ b/x/interchainqueries/keeper/keeper.go
@@ -83,10 +83,10 @@ func (k Keeper) SetLastRegisteredQueryKey(ctx sdk.Context, id uint64) {
 	store.Set(types.LastRegisteredQueryIDKey, sdk.Uint64ToBigEndian(id))
 }
 
-func (k Keeper) SaveQuery(ctx sdk.Context, query types.RegisteredQuery) error {
+func (k Keeper) SaveQuery(ctx sdk.Context, query *types.RegisteredQuery) error {
 	store := ctx.KVStore(k.storeKey)
 
-	bz, err := k.cdc.Marshal(&query)
+	bz, err := k.cdc.Marshal(query)
 	if err != nil {
 		return sdkerrors.Wrapf(types.ErrProtoMarshal, "failed to marshal registered query: %v", err)
 	}
@@ -137,28 +137,16 @@ func (k Keeper) RemoveQueryByID(ctx sdk.Context, id uint64) {
 	store.Delete(types.GetRegisteredQueryByIDKey(id))
 }
 
-func (k Keeper) SaveKVQueryResult(ctx sdk.Context, id uint64, result *types.QueryResult) error {
-	store := ctx.KVStore(k.storeKey)
-
-	if result.KvResults != nil {
-		cleanResult := clearQueryResult(result)
-		bz, err := k.cdc.Marshal(&cleanResult)
-		if err != nil {
-			return sdkerrors.Wrapf(types.ErrProtoMarshal, "failed to marshal result result: %v", err)
-		}
-
-		store.Set(types.GetRegisteredQueryResultByIDKey(id), bz)
-
-		if err = k.UpdateLastRemoteHeight(ctx, id, result.Height); err != nil {
-			return sdkerrors.Wrapf(err, "failed to update last remote height for a result with id %d: %v", id, err)
-		}
-
-		if err = k.UpdateLastLocalHeight(ctx, id, uint64(ctx.BlockHeight())); err != nil {
-			return sdkerrors.Wrapf(err, "failed to update last local height for a result with id %d: %v", id, err)
-		}
+// SaveKVQueryResult saves the result of the query and updates the query's local and remote heights
+// of last result submission. The result's height must be greater than the current remote height of
+// the last query result submission, otherwise operation fails.
+func (k Keeper) SaveKVQueryResult(ctx sdk.Context, queryID uint64, result *types.QueryResult) error {
+	query, err := k.getRegisteredQueryByID(ctx, queryID)
+	if err != nil {
+		return sdkerrors.Wrap(err, "failed to get registered query")
 	}
-	k.Logger(ctx).Debug("Successfully saved query result", "result", &result)
-	return nil
+
+	return k.saveKVQueryResult(ctx, query, result)
 }
 
 // SaveTransactionAsProcessed simply stores a key (SubmittedTxKey + bigEndianBytes(queryID) + tx_hash) with
@@ -200,44 +188,89 @@ func (k Keeper) removeQueryResultByID(ctx sdk.Context, id uint64) {
 	store.Delete(types.GetRegisteredQueryResultByIDKey(id))
 }
 
+// UpdateLastLocalHeight updates the relative query's local height of the last result submission.
 func (k Keeper) UpdateLastLocalHeight(ctx sdk.Context, queryID uint64, newLocalHeight uint64) error {
-	store := ctx.KVStore(k.storeKey)
-
-	bz := store.Get(types.GetRegisteredQueryByIDKey(queryID))
-	if bz == nil {
-		return sdkerrors.Wrapf(types.ErrInvalidQueryID, "query with ID %d not found", queryID)
-	}
-
-	var query types.RegisteredQuery
-	if err := k.cdc.Unmarshal(bz, &query); err != nil {
-		return sdkerrors.Wrapf(types.ErrProtoUnmarshal, "failed to unmarshal registered query: %v", err)
+	query, err := k.getRegisteredQueryByID(ctx, queryID)
+	if err != nil {
+		return sdkerrors.Wrap(err, "failed to get registered query")
 	}
 
 	query.LastSubmittedResultLocalHeight = newLocalHeight
-
 	return k.SaveQuery(ctx, query)
 }
 
+// UpdateLastRemoteHeight updates the relative query's remote height of the last result submission.
+// The height must be greater than the current remote height of the last query result submission,
+// otherwise operation fails.
 func (k Keeper) UpdateLastRemoteHeight(ctx sdk.Context, queryID uint64, newRemoteHeight uint64) error {
-	store := ctx.KVStore(k.storeKey)
+	query, err := k.getRegisteredQueryByID(ctx, queryID)
+	if err != nil {
+		return sdkerrors.Wrap(err, "failed to get registered query")
+	}
 
+	if err := k.checkLastRemoteHeight(ctx, *query, newRemoteHeight); err != nil {
+		return sdkerrors.Wrap(types.ErrInvalidHeight, err.Error())
+	}
+	k.updateLastRemoteHeight(ctx, query, newRemoteHeight)
+	return k.SaveQuery(ctx, query)
+}
+
+// saveKVQueryResult saves the result of the query and updates the query's local and remote heights
+// of last result submission. The result's height must be greater than the current remote height of
+// the last query result submission, otherwise operation fails.
+func (k Keeper) saveKVQueryResult(ctx sdk.Context, query *types.RegisteredQuery, result *types.QueryResult) error {
+	store := ctx.KVStore(k.storeKey)
+	cleanResult := clearQueryResult(result)
+	bz, err := k.cdc.Marshal(&cleanResult)
+	if err != nil {
+		return sdkerrors.Wrapf(types.ErrProtoMarshal, "failed to marshal result result: %v", err)
+	}
+	store.Set(types.GetRegisteredQueryResultByIDKey(query.Id), bz)
+
+	k.updateLastRemoteHeight(ctx, query, result.Height)
+	k.updateLastLocalHeight(ctx, query, uint64(ctx.BlockHeight()))
+	if err := k.SaveQuery(ctx, query); err != nil {
+		return sdkerrors.Wrapf(err, "failed to save query %d: %v", query.Id, err)
+	}
+
+	k.Logger(ctx).Debug("Successfully saved query result", "result", &result)
+	return nil
+}
+
+// updateLastLocalHeight updates the query's local height of the last result submission.
+func (k Keeper) updateLastLocalHeight(ctx sdk.Context, query *types.RegisteredQuery, height uint64) {
+	query.LastSubmittedResultLocalHeight = height
+	k.Logger(ctx).Debug("Updated last local height on given query", "queryID", query.Id, "new_local_height", height)
+}
+
+// checkLastRemoteHeight checks whether the given height is greater than the query's remote height
+// of the last result submission.
+func (k Keeper) checkLastRemoteHeight(ctx sdk.Context, query types.RegisteredQuery, height uint64) error {
+	if query.LastSubmittedResultRemoteHeight >= height {
+		return fmt.Errorf("result's remote height %d is less than or equal to last result's remote height %d", height, query.LastSubmittedResultRemoteHeight)
+	}
+	return nil
+}
+
+// updateLastRemoteHeight updates query's remote height of the last result submission.
+func (k Keeper) updateLastRemoteHeight(ctx sdk.Context, query *types.RegisteredQuery, height uint64) {
+	query.LastSubmittedResultRemoteHeight = height
+	k.Logger(ctx).Debug("Updated last remote height on given query", "queryID", query.Id, "new_remote_height", height)
+}
+
+// getRegisteredQueryByID loads a query by the given ID from the store.
+func (k Keeper) getRegisteredQueryByID(ctx sdk.Context, queryID uint64) (*types.RegisteredQuery, error) {
+	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.GetRegisteredQueryByIDKey(queryID))
 	if bz == nil {
-		return sdkerrors.Wrapf(types.ErrInvalidQueryID, "query with ID %d not found", queryID)
+		return nil, sdkerrors.Wrapf(types.ErrInvalidQueryID, "query with ID %d not found", queryID)
 	}
 
 	var query types.RegisteredQuery
 	if err := k.cdc.Unmarshal(bz, &query); err != nil {
-		return sdkerrors.Wrapf(types.ErrProtoUnmarshal, "failed to unmarshal registered query: %v", err)
+		return nil, sdkerrors.Wrapf(types.ErrProtoUnmarshal, "failed to unmarshal registered query: %v", err)
 	}
-
-	if query.LastSubmittedResultRemoteHeight >= newRemoteHeight {
-		return sdkerrors.Wrapf(types.ErrInvalidHeight, "can't save query result for height %d: result height can't be less or equal then last submitted query result height %d", newRemoteHeight, query.LastSubmittedResultRemoteHeight)
-	}
-
-	query.LastSubmittedResultRemoteHeight = newRemoteHeight
-	k.Logger(ctx).Debug("Updated last remote height on given query", "queryID", queryID, "new remote height", newRemoteHeight)
-	return k.SaveQuery(ctx, query)
+	return &query, nil
 }
 
 // We don't need to store proofs or transactions, so we just remove unnecessary fields

--- a/x/interchainqueries/keeper/keeper_test.go
+++ b/x/interchainqueries/keeper/keeper_test.go
@@ -578,7 +578,7 @@ func (suite *KeeperTestSuite) TestGetAllRegisteredQueries() {
 
 			iqkeeper := suite.GetNeutronZoneApp(suite.ChainA).InterchainQueriesKeeper
 			for _, query := range tt.queries {
-				iqkeeper.SaveQuery(ctx, *query)
+				iqkeeper.SaveQuery(ctx, query)
 			}
 
 			allQueries := iqkeeper.GetAllRegisteredQueries(ctx)

--- a/x/interchainqueries/keeper/msg_server.go
+++ b/x/interchainqueries/keeper/msg_server.go
@@ -55,7 +55,7 @@ func (k msgServer) RegisterInterchainQuery(goCtx context.Context, msg *types.Msg
 
 	params := k.GetParams(ctx)
 
-	registeredQuery := types.RegisteredQuery{
+	registeredQuery := &types.RegisteredQuery{
 		Id:                 lastID,
 		Owner:              msg.Sender,
 		TransactionsFilter: msg.TransactionsFilter,
@@ -69,7 +69,7 @@ func (k msgServer) RegisterInterchainQuery(goCtx context.Context, msg *types.Msg
 
 	k.SetLastRegisteredQueryKey(ctx, lastID)
 
-	if err := k.CollectDeposit(ctx, registeredQuery); err != nil {
+	if err := k.CollectDeposit(ctx, *registeredQuery); err != nil {
 		ctx.Logger().Debug("RegisterInterchainQuery: failed to collect deposit", "message", &msg, "error", err)
 		return nil, sdkerrors.Wrapf(err, "failed to collect deposit")
 	}
@@ -79,7 +79,7 @@ func (k msgServer) RegisterInterchainQuery(goCtx context.Context, msg *types.Msg
 		return nil, sdkerrors.Wrapf(err, "failed to save query: %v", err)
 	}
 
-	ctx.EventManager().EmitEvents(getEventsQueryUpdated(&registeredQuery))
+	ctx.EventManager().EmitEvents(getEventsQueryUpdated(registeredQuery))
 
 	return &types.MsgRegisterInterchainQueryResponse{Id: lastID}, nil
 }
@@ -143,8 +143,7 @@ func (k msgServer) UpdateInterchainQuery(goCtx context.Context, msg *types.MsgUp
 		query.TransactionsFilter = msg.NewTransactionsFilter
 	}
 
-	err = k.SaveQuery(ctx, *query)
-	if err != nil {
+	if err := k.SaveQuery(ctx, query); err != nil {
 		ctx.Logger().Debug("UpdateInterchainQuery: failed to save query", "message", &msg, "error", err)
 		return nil, sdkerrors.Wrapf(err, "failed to save query by query id: %v", err)
 	}
@@ -178,7 +177,9 @@ func (k msgServer) SubmitQueryResult(goCtx context.Context, msg *types.MsgSubmit
 		if !types.InterchainQueryType(query.QueryType).IsKV() {
 			return nil, sdkerrors.Wrapf(types.ErrInvalidType, "invalid query result for query type: %s", query.QueryType)
 		}
-
+		if err := k.checkLastRemoteHeight(ctx, *query, msg.Result.Height); err != nil {
+			return nil, sdkerrors.Wrap(types.ErrInvalidHeight, err.Error())
+		}
 		if len(msg.Result.KvResults) != len(query.Keys) {
 			return nil, sdkerrors.Wrapf(types.ErrInvalidSubmittedResult, "KV keys length from result is not equal to registered query keys length: %v != %v", len(msg.Result.KvResults), query.Keys)
 		}
@@ -246,7 +247,7 @@ func (k msgServer) SubmitQueryResult(goCtx context.Context, msg *types.MsgSubmit
 			}
 		}
 
-		if err = k.SaveKVQueryResult(ctx, msg.QueryId, msg.Result); err != nil {
+		if err = k.saveKVQueryResult(ctx, query, msg.Result); err != nil {
 			ctx.Logger().Error("SubmitQueryResult: failed to SaveKVQueryResult",
 				"error", err, "query", query, "message", msg)
 			return nil, sdkerrors.Wrapf(err, "failed to SaveKVQueryResult: %v", err)


### PR DESCRIPTION
**task:** https://p2pvalidator.atlassian.net/browse/NTRN-353

- reduce number of interactions with Store on `SubmitQueryResult`;
- add early check of KV query result's remote height for compliance.

**tests:** https://github.com/neutron-org/neutron-tests/actions/runs/4204510406

here's the result of SubmitQueryResult calls for neutron interchainqueries keeper tests without and with the changes of this PR:

| test name | gas consumption original | gas consumption with the improvement |
------------|--------------------------|----------------------------------------|
| invalid query id | 1027 | 1027 |
| valid KV storage proof | 31866 | **21860** |
| invalid number of KvResults | 1495 | 1495 |
| invalid query type | 1363 | 1363 |
| nil proof | 5980 | 5980 |
| non-registered key in KV result | 5980 | 5980 |
| non-registered path in KV result | 5980 | 5980 |
| non existence KV proof | 24726 | **15440** |
| header with invalid height | 3987 | 3987 |
| invalid KV storage value | 5980 | 5980 |
| query result height is too old | 16303 | **1504** |
| non existence KV proof with special bytes in key | 27201 | **17015** |