### PR TITLE
Make disabling of CCV msg handler configurable

### DIFF
--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -23,7 +23,7 @@ type HandlerOptions struct {
 	TXCounterStoreKey sdk.StoreKey
 }
 
-func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
+func NewAnteHandler(options HandlerOptions, disableCcvHandler bool) (sdk.AnteHandler, error) {
 	if options.AccountKeeper == nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for AnteHandler")
 	}
@@ -65,6 +65,13 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewAnteDecorator(options.IBCKeeper),
+	}
+
+	if !disableCcvHandler {
+		print("Adding CCV Ante Decorator\n")
+		anteDecorators = append(anteDecorators, consumerante.NewMsgFilterDecorator(options.ConsumerKeeper))
+	} else {
+		print("Not adding CCV Ante Decorator\n")
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -68,10 +68,7 @@ func NewAnteHandler(options HandlerOptions, disableCcvHandler bool) (sdk.AnteHan
 	}
 
 	if !disableCcvHandler {
-		print("Adding CCV Ante Decorator\n")
 		anteDecorators = append(anteDecorators, consumerante.NewMsgFilterDecorator(options.ConsumerKeeper))
-	} else {
-		print("Not adding CCV Ante Decorator\n")
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -50,7 +50,6 @@ func NewAnteHandler(options HandlerOptions, disableCcvHandler bool) (sdk.AnteHan
 		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey),
 		ante.NewRejectExtensionOptionsDecorator(),
-		consumerante.NewMsgFilterDecorator(options.ConsumerKeeper),
 		consumerante.NewDisabledModulesDecorator("/cosmos.evidence", "/cosmos.slashing"),
 		ante.NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),

--- a/app/app.go
+++ b/app/app.go
@@ -814,6 +814,8 @@ func New(
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 
+	disableCcvHandler := cast.ToBool(appOpts.Get("disable-ccv-handler"))
+
 	anteHandler, err := NewAnteHandler(
 		HandlerOptions{
 			HandlerOptions: ante.HandlerOptions{
@@ -828,6 +830,7 @@ func New(
 			TXCounterStoreKey: keys[wasm.StoreKey],
 			ConsumerKeeper:    app.ConsumerKeeper,
 		},
+		disableCcvHandler,
 	)
 	if err != nil {
 		panic(err)

--- a/network/init-neutrond.sh
+++ b/network/init-neutrond.sh
@@ -612,3 +612,4 @@ sed -i -e 's/\"security_address\":.*/\"security_address\":\"'"$DAO_CONTRACT_ADDR
 sed -i -e 's/\"limit\":.*/\"limit\":5/g' "$CHAIN_DIR/config/genesis.json"
 sed -i -e 's/\"allow_messages\":.*/\"allow_messages\": [\"*\"]/g' "$CHAIN_DIR/config/genesis.json"
 
+sed -i -e '1s/^/disable-ccv-handler = true\n/' "$CHAIN_DIR/config/app.toml"


### PR DESCRIPTION
This PR allows configuring if arbitrary messages should be disabled while the chain is not interchain-secured.
The option "disable-ccv-handler" in `app.toml` being set to true disables message filtering for the test environment.

Passing tests show that disabling works properly (in the other case tests wouldn't pass).

To test if messages are filtered if the option is "false" or not even present in the config do the following:
1. Comment the last line of `init-neutrond.sh` (`sed -i -e '1s/^/disable-ccv-handler...`)
2. Run the chain via `make start`
3. Run the following command:
`neutrond tx bank send demowallet1 neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff 1untrn --fees 125000untrn --keyring-backend test --home data/test-1 --chain-id test-1 -y -b block`
It should fail with `raw_log: tx contains unsupported message types at height` in the output.