### PR TITLE
ccv msg filter build tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.20-bullseye
 RUN apt-get update && apt-get install -y jq
 EXPOSE 26656 26657 1317 9090
 COPY --from=app . /opt/neutron
-RUN cd /opt/neutron && make install
+RUN cd /opt/neutron && make install-test-binary
 WORKDIR /opt/neutron
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD \

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,14 @@ endif
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
+build_tags_test_binary = $(build_tags)
+build_tags_test_binary += skip_ccv_msg_filter
+
 whitespace :=
 empty = $(whitespace) $(whitespace)
 comma := ,
 build_tags_comma_sep := $(subst $(empty),$(comma),$(build_tags))
+build_tags_test_binary_comma_sep := $(subst $(empty),$(comma),$(build_tags_test_binary))
 
 # process linker flags
 
@@ -70,6 +74,7 @@ ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
 BUILD_FLAGS := -tags "$(build_tags_comma_sep)" -ldflags '$(ldflags)' -trimpath
+BUILD_FLAGS_TEST_BINARY := -tags "$(build_tags_test_binary_comma_sep)" -ldflags '$(ldflags)' -trimpath
 
 # The below include contains the tools and runsim targets.
 include contrib/devtools/Makefile
@@ -91,6 +96,9 @@ endif
 
 install: check_version go.sum
 	go install -mod=readonly $(BUILD_FLAGS) ./cmd/neutrond
+
+install-test-binary: check_version go.sum
+	go install -mod=readonly $(BUILD_FLAGS_TEST_BINARY) ./cmd/neutrond
 
 ########################################
 ### Tools & dependencies
@@ -173,7 +181,7 @@ proto-format:
 	test test-all test-build test-cover test-unit test-race \
 	test-sim-import-export \
 
-init: kill-dev install
+init: kill-dev install-test-binary
 	@echo "Building gaiad binary..."
 	@cd ./../gaia/ && make install
 	@echo "Initializing both blockchains..."
@@ -182,14 +190,7 @@ init: kill-dev install
 	./network/hermes/restore-keys.sh
 	./network/hermes/create-conn.sh
 
-init-golang-rly: kill-dev install
-	@echo "Initializing both blockchains..."
-	./network/init.sh
-	./network/start.sh
-	@echo "Initializing relayer..."
-	./network/relayer/interchain-acc-config/rly.sh
-
-start: kill-dev install
+start: kill-dev install-test-binary
 	@echo "Starting up neutrond alone..."
 	BINARY=neutrond CHAINID=test-1 P2PPORT=26656 RPCPORT=26657 RESTPORT=1317 ROSETTA=8080 GRPCPORT=8090 GRPCWEB=8091 STAKEDENOM=untrn \
 	./network/init.sh && ./network/init-neutrond.sh && ./network/start.sh

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -69,10 +69,10 @@ func NewAnteHandler(options HandlerOptions, logger log.Logger) (sdk.AnteHandler,
 
 	// Don't delete it even if IDE tells you so.
 	// This constant depends on build tag.
-	if !SKIP_CCV_MSG_FILTER {
+	if !SkipCcvMsgFilter {
 		anteDecorators = append(anteDecorators, consumerante.NewMsgFilterDecorator(options.ConsumerKeeper))
 	} else {
-		logger.Error("WARNING: LAUNCHED WITH SKIP_CCV_MSG_FILTER\nTHIS IS NOT A PRODUCTION BUILD")
+		logger.Error("WARNING: LAUNCHED WITH skip_ccv_msg_filter. THIS IS NOT A PRODUCTION BUILD")
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -50,7 +50,6 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey),
 		ante.NewRejectExtensionOptionsDecorator(),
-		consumerante.NewMsgFilterDecorator(options.ConsumerKeeper),
 		consumerante.NewDisabledModulesDecorator("/cosmos.evidence", "/cosmos.slashing"),
 		ante.NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),
@@ -65,6 +64,10 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewAnteDecorator(options.IBCKeeper),
+	}
+
+	if !SKIP_CCV_MSG_FILTER {
+		anteDecorators = append(anteDecorators, consumerante.NewMsgFilterDecorator(options.ConsumerKeeper))
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -10,6 +10,7 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v4/modules/core/keeper"
 	consumerante "github.com/cosmos/interchain-security/app/consumer/ante"
 	ibcconsumerkeeper "github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
@@ -23,7 +24,7 @@ type HandlerOptions struct {
 	TXCounterStoreKey sdk.StoreKey
 }
 
-func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
+func NewAnteHandler(options HandlerOptions, logger log.Logger) (sdk.AnteHandler, error) {
 	if options.AccountKeeper == nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for AnteHandler")
 	}
@@ -66,8 +67,12 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ibcante.NewAnteDecorator(options.IBCKeeper),
 	}
 
+	// Don't delete it even if IDE tells you so.
+	// This constant depends on build tag.
 	if !SKIP_CCV_MSG_FILTER {
 		anteDecorators = append(anteDecorators, consumerante.NewMsgFilterDecorator(options.ConsumerKeeper))
+	} else {
+		logger.Error("WARNING: LAUNCHED WITH SKIP_CCV_MSG_FILTER\nTHIS IS NOT A PRODUCTION BUILD")
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -72,7 +72,7 @@ func NewAnteHandler(options HandlerOptions, logger log.Logger) (sdk.AnteHandler,
 	if !SkipCcvMsgFilter {
 		anteDecorators = append(anteDecorators, consumerante.NewMsgFilterDecorator(options.ConsumerKeeper))
 	} else {
-		logger.Error("WARNING: LAUNCHED WITH skip_ccv_msg_filter. THIS IS NOT A PRODUCTION BUILD")
+		logger.Error("WARNING: BUILT WITH skip_ccv_msg_filter. THIS IS NOT A PRODUCTION BUILD")
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/app.go
+++ b/app/app.go
@@ -828,6 +828,7 @@ func New(
 			TXCounterStoreKey: keys[wasm.StoreKey],
 			ConsumerKeeper:    app.ConsumerKeeper,
 		},
+		app.Logger(),
 	)
 	if err != nil {
 		panic(err)

--- a/app/ccv_msg_filter_add.go
+++ b/app/ccv_msg_filter_add.go
@@ -1,0 +1,5 @@
+//go:build !skip_ccv_msg_filter
+
+package app
+
+const SKIP_CCV_MSG_FILTER = false

--- a/app/ccv_msg_filter_add.go
+++ b/app/ccv_msg_filter_add.go
@@ -2,4 +2,4 @@
 
 package app
 
-const SKIP_CCV_MSG_FILTER = false
+const SkipCcvMsgFilter = false

--- a/app/ccv_msg_filter_skip.go
+++ b/app/ccv_msg_filter_skip.go
@@ -1,0 +1,5 @@
+//go:build skip_ccv_msg_filter
+
+package app
+
+const SKIP_CCV_MSG_FILTER = true

--- a/app/ccv_msg_filter_skip.go
+++ b/app/ccv_msg_filter_skip.go
@@ -2,4 +2,4 @@
 
 package app
 
-const SKIP_CCV_MSG_FILTER = true
+const SkipCcvMsgFilter = true


### PR DESCRIPTION
This PR allows configuring if arbitrary messages should be disabled while the chain is not interchain-secured at built time.
The build tag "skip_ccv_msg_filter" being set to true disables message filtering for the test environment.

Passing tests show that disabling works properly (in the other case tests wouldn't pass).

To test if messages are filtered if the option is "false" or not even present in the config do the following:
1. Comment the line 53 of `Makefile` (`build_tags_test_binary += skip_ccv_msg_filter`)
2. Run the chain via `make start`
3. Run the following command:
`neutrond tx bank send demowallet1 neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff 1untrn --fees 125000untrn --keyring-backend test --home data/test-1 --chain-id test-1 -y -b block`
It should fail with `raw_log: tx contains unsupported message types at height` in the output.