### PR TITLE
Set genesis slashing parameters

### DIFF
--- a/network/init-neutrond.sh
+++ b/network/init-neutrond.sh
@@ -611,4 +611,8 @@ sed -i -e 's/\"fee_collector_address\":.*/\"fee_collector_address\":\"'"$TREASUR
 sed -i -e 's/\"security_address\":.*/\"security_address\":\"'"$DAO_CONTRACT_ADDRESS"'\",/g' "$CHAIN_DIR/config/genesis.json"
 sed -i -e 's/\"limit\":.*/\"limit\":5/g' "$CHAIN_DIR/config/genesis.json"
 sed -i -e 's/\"allow_messages\":.*/\"allow_messages\": [\"*\"]/g' "$CHAIN_DIR/config/genesis.json"
+sed -i -e 's/\"signed_blocks_window\":.*/\"signed_blocks_window\":\"140000\",/g' "$CHAIN_DIR/config/genesis.json"
+sed -i -e 's/\"min_signed_per_window\":.*/\"min_signed_per_window\":\"0.050000000000000000\",/g' "$CHAIN_DIR/config/genesis.json"
+sed -i -e 's/\"slash_fraction_double_sign\":.*/\"slash_fraction_double_sign\":\"0.010000000000000000\",/g' "$CHAIN_DIR/config/genesis.json"
+sed -i -e 's/\"slash_fraction_downtime\":.*/\"slash_fraction_downtime\":\"0.000100000000000000\"/g' "$CHAIN_DIR/config/genesis.json"
 


### PR DESCRIPTION
This PR will add `sed` command to update slashing parameters of the genesis according to https://www.notion.so/Mainnet-Launch-Walkthrough-04b66367097844cd89ead4b38b5457bb?pvs=4#e032443e609c421189790af87fb293d7

It is required to have specific slashing parameter other than parameters by default. 
New values:
1. `signed_blocks_window: 140000`. About 4 days, with block time = 2.5s
2. `min_signed_per_window: 0.050000000000000000`
3. `slash_fraction_double_sign: 0.010000000000000000`
4. `slash_fraction_downtime: 0.000100000000000000`