### PR TITLE
feat: enable cosmwasm_1_1 and cosmwasm_1_2

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -532,7 +532,7 @@ func New(
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
 	// NOTE: we need staking feature here even if there is no staking module anymore because cosmwasm-std in the CosmWasm SDK requires this feature
-	supportedFeatures := "iterator,stargate,staking,neutron"
+	supportedFeatures := "iterator,stargate,staking,neutron,cosmwasm_1_1,cosmwasm_1_2"
 
 	// register the proposal types
 	adminRouter := govtypes.NewRouter()

--- a/app/app.go
+++ b/app/app.go
@@ -532,6 +532,8 @@ func New(
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
 	// NOTE: we need staking feature here even if there is no staking module anymore because cosmwasm-std in the CosmWasm SDK requires this feature
+	// NOTE: cosmwasm_1_2 feature enables GovMsg::VoteWeighted, which doesn't work with Neutron, because it uses its own custom governance,
+	//       however, cosmwasm_1_2 also enables WasmMsg::Instantiate2, which works as one could expect
 	supportedFeatures := "iterator,stargate,staking,neutron,cosmwasm_1_1,cosmwasm_1_2"
 
 	// register the proposal types


### PR DESCRIPTION
`cosmwasm_1_1` adds:
- [x] `BankQuery::Supply` — tested manually, works like expected.

`cosmwasm_1_2` adds:
- [x] `GovMsg::VoteWeighted` — tested manually, simulation fails with `rpc error: code = Unknown desc = failed to execute message; message index: 0: dispatch: submessages: : invalid request [cosmos/cosmos-sdk@v0.45.15/x/gov/types/msgs.go:245] With gas wanted: '0' and gas used: '107040' : unknown request`, I guess that's an expected error?
- [x] `WasmMsg::Instantiate2` — tested manually, works like expected.