### PR TITLE
fix: `make start`: GRPC_PORT setting didn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ init: kill-dev install-test-binary
 
 start: kill-dev install-test-binary
 	@echo "Starting up neutrond alone..."
-	BINARY=neutrond CHAINID=test-1 P2PPORT=26656 RPCPORT=26657 RESTPORT=1317 ROSETTA=8080 GRPCPORT=8090 GRPCWEB=8091 STAKEDENOM=untrn \
+	export BINARY=neutrond CHAINID=test-1 P2PPORT=26656 RPCPORT=26657 RESTPORT=1317 ROSETTA=8080 GRPCPORT=8090 GRPCWEB=8091 STAKEDENOM=untrn && \
 	./network/init.sh && ./network/init-neutrond.sh && ./network/start.sh
 
 start-rly:


### PR DESCRIPTION
The problem is that GRPC_PORT setting affects execution of `network/start.sh`, but, without using `export`, environment variables did only affect `network/init.sh`. This PR fixes this oversight.