### PR TITLE
fix: Add googleapis as dep in buf.yaml

### DIFF
--- a/third_party/proto/buf.lock
+++ b/third_party/proto/buf.lock
@@ -4,7 +4,10 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
-    branch: main
-    commit: bee5511075b7499da6178d9e4aaa628b
-    digest: b1-rrBIustouD-S80cVoZ_rM0qJsmei9AgbXy9GPQu6vxg=
-    create_time: 2021-12-02T20:01:17.069307Z
+    commit: 5e5b9fdd01804356895f8f79a6f1ddc1
+    digest: shake256:0b85da49e2e5f9ebc4806eae058e2f56096ff3b1c59d1fb7c190413dd15f45dd456f0b69ced9059341c80795d2b6c943de15b120a9e0308b499e43e4b5fc2952
+  - remote: buf.build
+    owner: googleapis
+    repository: googleapis
+    commit: 711e289f6a384c4caeebaff7c6931ade
+    digest: shake256:e08fb55dad7469f69df00304eed31427d2d1576e9aab31e6bf86642688e04caaf0372f15fe6974cf79432779a635b3ea401ca69c943976dc42749524e4c25d94

--- a/third_party/proto/buf.yaml
+++ b/third_party/proto/buf.yaml
@@ -6,6 +6,7 @@
 version: v1
 deps:
   - buf.build/cosmos/gogo-proto
+  - buf.build/googleapis/googleapis
 build:
   excludes:
     - google/protobuf


### PR DESCRIPTION
Without this `buf generate` fails as it cannot find `import "google/api/annotations.proto"` in `proto/transfer/v1/query.proto`.