### PR TITLE
feat: increase limit of wasm contracts #ntrn-107

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1256,6 +1256,6 @@ func (app *App) RegisterNodeService(clientCtx client.Context) {
 //   - allow for larger wasm files
 func overrideWasmVariables() {
 	// Override Wasm size limitation from WASMD.
-	wasmtypes.MaxWasmSize = 3 * 1024 * 1024
+	wasmtypes.MaxWasmSize = 1_677_722 // ~1.6 mb (1024 * 1024 * 1.6)
 	wasmtypes.MaxProposalWasmSize = wasmtypes.MaxWasmSize
 }

--- a/app/app.go
+++ b/app/app.go
@@ -352,6 +352,8 @@ func New(
 	wasmOpts []wasmkeeper.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
+	overrideWasmVariables()
+
 	appCodec := encodingConfig.Marshaler
 	legacyAmino := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
@@ -1248,4 +1250,12 @@ func (app *App) GetConsumerKeeper() ccvconsumerkeeper.Keeper {
 
 func (app *App) RegisterNodeService(clientCtx client.Context) {
 	nodeservice.RegisterNodeService(clientCtx, app.GRPCQueryRouter())
+}
+
+// overrideWasmVariables overrides the wasm variables to:
+//   - allow for larger wasm files
+func overrideWasmVariables() {
+	// Override Wasm size limitation from WASMD.
+	wasmtypes.MaxWasmSize = 3 * 1024 * 1024
+	wasmtypes.MaxProposalWasmSize = wasmtypes.MaxWasmSize
 }


### PR DESCRIPTION
https://hadronlabs.atlassian.net/browse/NTRN-107
Increased maximum allowed size of cosmwasm contract to 3mb.
Should be fine since we still taking gas from deploy.
Also there is nothing that stops users from deploying many contracts if they want to spam us with contract storage, so there is no reason to make it smaller.

It works. Tried with unoptimized contract with smaller limit, get: 
 uncompress wasm archive: max 716800 bytes: exceeds limit: create wasm contract failed"