### PR TITLE
Ensure deposit, withdraw and place/withdraw limit order correctly val…

### DIFF
--- a/x/dex/types/errors.go
+++ b/x/dex/types/errors.go
@@ -42,7 +42,7 @@ var (
 	ErrTickOutsideRange = sdkerrors.Register(
 		ModuleName,
 		1117,
-		"Supplying a tick > 559,680 is not allowed",
+		"abs(tick) + fee must be < 559,680",
 	)
 	ErrInvalidPoolDenom = sdkerrors.Register(
 		ModuleName,

--- a/x/dex/types/message_deposit.go
+++ b/x/dex/types/message_deposit.go
@@ -85,6 +85,9 @@ func (msg *MsgDeposit) ValidateBasic() error {
 		if msg.AmountsA[i].Equal(math.ZeroInt()) && msg.AmountsB[i].Equal(math.ZeroInt()) {
 			return ErrZeroDeposit
 		}
+		if err := ValidateTickFee(msg.TickIndexesAToB[i], msg.Fees[i]); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/x/dex/types/message_deposit_test.go
+++ b/x/dex/types/message_deposit_test.go
@@ -112,6 +112,30 @@ func TestMsgDeposit_ValidateBasic(t *testing.T) {
 			err: ErrZeroDeposit,
 		},
 		{
+			name: "invalid tick + fee upper",
+			msg: MsgDeposit{
+				Creator:         sample.AccAddress(),
+				Receiver:        sample.AccAddress(),
+				Fees:            []uint64{3},
+				TickIndexesAToB: []int64{559678},
+				AmountsA:        []math.Int{math.OneInt()},
+				AmountsB:        []math.Int{math.OneInt()},
+			},
+			err: ErrTickOutsideRange,
+		},
+		{
+			name: "invalid tick + fee lower",
+			msg: MsgDeposit{
+				Creator:         sample.AccAddress(),
+				Receiver:        sample.AccAddress(),
+				Fees:            []uint64{50},
+				TickIndexesAToB: []int64{-559631},
+				AmountsA:        []math.Int{math.OneInt()},
+				AmountsB:        []math.Int{math.OneInt()},
+			},
+			err: ErrTickOutsideRange,
+		},
+		{
 			name: "valid msg",
 			msg: MsgDeposit{
 				Creator:         sample.AccAddress(),

--- a/x/dex/types/message_place_limit_order.go
+++ b/x/dex/types/message_place_limit_order.go
@@ -90,6 +90,10 @@ func (msg *MsgPlaceLimitOrder) ValidateBasic() error {
 		}
 	}
 
+	if IsTickOutOfRange(msg.TickIndexInToOut) {
+		return ErrTickOutsideRange
+	}
+
 	return nil
 }
 

--- a/x/dex/types/message_place_limit_order_test.go
+++ b/x/dex/types/message_place_limit_order_test.go
@@ -82,6 +82,32 @@ func TestMsgPlaceLimitOrder_ValidateBasic(t *testing.T) {
 			err: ErrInvalidMaxAmountOutForMaker,
 		},
 		{
+			name: "tick outside range upper",
+			msg: MsgPlaceLimitOrder{
+				Creator:          sample.AccAddress(),
+				Receiver:         sample.AccAddress(),
+				TokenIn:          "TokenA",
+				TokenOut:         "TokenB",
+				TickIndexInToOut: 700_000,
+				AmountIn:         math.OneInt(),
+				OrderType:        LimitOrderType_GOOD_TIL_CANCELLED,
+			},
+			err: ErrTickOutsideRange,
+		},
+		{
+			name: "tick outside range lower",
+			msg: MsgPlaceLimitOrder{
+				Creator:          sample.AccAddress(),
+				Receiver:         sample.AccAddress(),
+				TokenIn:          "TokenA",
+				TokenOut:         "TokenB",
+				TickIndexInToOut: -600_000,
+				AmountIn:         math.OneInt(),
+				OrderType:        LimitOrderType_GOOD_TIL_CANCELLED,
+			},
+			err: ErrTickOutsideRange,
+		},
+		{
 			name: "valid msg",
 			msg: MsgPlaceLimitOrder{
 				Creator:          sample.AccAddress(),

--- a/x/dex/types/message_withdrawl.go
+++ b/x/dex/types/message_withdrawl.go
@@ -76,6 +76,9 @@ func (msg *MsgWithdrawal) ValidateBasic() error {
 		if msg.SharesToRemove[i].LTE(math.ZeroInt()) {
 			return ErrZeroWithdraw
 		}
+		if err := ValidateTickFee(msg.TickIndexesAToB[i], msg.Fees[i]); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/x/dex/types/message_withdrawl_test.go
+++ b/x/dex/types/message_withdrawl_test.go
@@ -93,6 +93,28 @@ func TestMsgWithdrawal_ValidateBasic(t *testing.T) {
 			err: ErrZeroWithdraw,
 		},
 		{
+			name: "invalid tick + fee upper",
+			msg: MsgWithdrawal{
+				Creator:         sample.AccAddress(),
+				Receiver:        sample.AccAddress(),
+				Fees:            []uint64{3},
+				TickIndexesAToB: []int64{559678},
+				SharesToRemove:  []math.Int{math.OneInt()},
+			},
+			err: ErrTickOutsideRange,
+		},
+		{
+			name: "invalid tick + fee lower",
+			msg: MsgWithdrawal{
+				Creator:         sample.AccAddress(),
+				Receiver:        sample.AccAddress(),
+				Fees:            []uint64{50},
+				TickIndexesAToB: []int64{-559631},
+				SharesToRemove:  []math.Int{math.OneInt()},
+			},
+			err: ErrTickOutsideRange,
+		},
+		{
 			name: "valid msg",
 			msg: MsgWithdrawal{
 				Creator:         sample.AccAddress(),

--- a/x/dex/types/price.go
+++ b/x/dex/types/price.go
@@ -33,5 +33,14 @@ func MustCalcPrice(relativeTickIndex int64) math_utils.PrecDec {
 }
 
 func IsTickOutOfRange(tickIndex int64) bool {
-	return tickIndex > 0 && uint64(tickIndex) > MaxTickExp
+	return utils.Abs(tickIndex) > MaxTickExp
+}
+
+func ValidateTickFee(tick int64, fee uint64) error {
+	// Ensure |tick| + fee <= MaxTickExp
+	// NOTE: Ugly arithmetic is to ensure that we don't overflow uint64
+	if utils.Abs(tick) > MaxTickExp-fee {
+		return ErrTickOutsideRange
+	}
+	return nil
 }


### PR DESCRIPTION
  Ensure deposit, withdraw and place/withdraw limit order correctly validate inputs to ensure that abs(tick) + fee < MaxTickExp

    This not only provides better validation for transactions that will fail later
    price checks, but also ensures that tick + fee combinations that could overflow an
    int64 are not allowed into the system.