### PR TITLE
Fix typo in registered query CLI description

### DIFF
--- a/x/interchainqueries/client/cli/query.go
+++ b/x/interchainqueries/client/cli/query.go
@@ -40,7 +40,7 @@ func GetQueryCmd(_ string) *cobra.Command {
 func CmdQueryRegisteredQuery() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "registered-query [id]",
-		Short: "queries all the interchain queries in the module",
+		Short: "queries registered interchain query by id",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)


### PR DESCRIPTION
This PR changes the description of the registered-query CLI to be accurate to what it does.