### PR TITLE
refactor(cli): remove ValidateBasic in cli

### DIFF
--- a/x/dex/client/cli/tx_cancel_limit_order.go
+++ b/x/dex/client/cli/tx_cancel_limit_order.go
@@ -25,9 +25,6 @@ func CmdCancelLimitOrder() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				args[0],
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/dex/client/cli/tx_deposit.go
+++ b/x/dex/client/cli/tx_deposit.go
@@ -108,9 +108,6 @@ func CmdDeposit() *cobra.Command {
 				FeesUint,
 				DepositOptions,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/dex/client/cli/tx_multi_hop_swap.go
+++ b/x/dex/client/cli/tx_multi_hop_swap.go
@@ -62,9 +62,6 @@ func CmdMultiHopSwap() *cobra.Command {
 				exitLimitPriceDec,
 				pickBest,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/dex/client/cli/tx_place_limit_order.go
+++ b/x/dex/client/cli/tx_place_limit_order.go
@@ -93,9 +93,6 @@ func CmdPlaceLimitOrder() *cobra.Command {
 				goodTil,
 				maxAmountOutIntP,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/dex/client/cli/tx_withdrawl.go
+++ b/x/dex/client/cli/tx_withdrawl.go
@@ -78,9 +78,6 @@ func CmdWithdrawal() *cobra.Command {
 				TicksIndexesInt,
 				FeesUint,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/dex/client/cli/tx_withdrawl_filled_limit_order.go
+++ b/x/dex/client/cli/tx_withdrawl_filled_limit_order.go
@@ -25,9 +25,6 @@ func CmdWithdrawFilledLimitOrder() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				args[0],
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/interchainqueries/client/cli/tx.go
+++ b/x/interchainqueries/client/cli/tx.go
@@ -49,9 +49,6 @@ func RemoveInterchainQueryCmd() *cobra.Command {
 			}
 
 			msg := types.NewMsgRemoveInterchainQuery(sender, queryID)
-			if err = msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
 		},
@@ -90,10 +87,6 @@ func SubmitQueryResultCmd() *cobra.Command {
 			msg := types.MsgSubmitQueryResult{QueryId: queryID, Sender: string(sender)}
 			if err := json.Unmarshal(result, &msg.Result); err != nil {
 				return fmt.Errorf("failed to unmarshal query result: %w", err)
-			}
-
-			if err = msg.ValidateBasic(); err != nil {
-				return err
 			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)


### PR DESCRIPTION
The `ValidateBasic` function has been called in the `GenerateOrBroadcastTxWithFactory` function, so we no longer need to add the `ValidateBasic` function when writing Cli. Related PRs can be viewed at: https://github.com/cosmos/cosmos-sdk/pull/9236#discussion_r623803504