### PR TITLE
fix: added /neutron.cron.Query/Params to stargate allowlist

### DIFF
--- a/wasmbinding/stargate_allowlist.go
+++ b/wasmbinding/stargate_allowlist.go
@@ -8,6 +8,7 @@ import (
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	ibcconnectiontypes "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
+	crontypes "github.com/neutron-org/neutron/v2/x/cron/types"
 
 	dextypes "github.com/neutron-org/neutron/v2/x/dex/types"
 	feeburnertypes "github.com/neutron-org/neutron/v2/x/feeburner/types"
@@ -48,6 +49,9 @@ func AcceptedStargateQueries() wasmkeeper.AcceptedStargateQueries {
 		// interchaintxs
 		"/neutron.interchaintxs.v1.Query/Params":                   &interchaintxstypes.QueryParamsResponse{},
 		"/neutron.interchaintxs.v1.Query/InterchainAccountAddress": &interchaintxstypes.QueryInterchainAccountAddressResponse{},
+
+		// cron
+		"/neutron.cron.Query/Params": &crontypes.QueryParamsResponse{},
 
 		// interchainqueries
 		"/neutron.interchainqueries.Query/Params":            &interchainqueriestypes.QueryParamsResponse{},


### PR DESCRIPTION
This PR allows smart contracts to query cron module parameters via stargate. No tests are provided because this has been tested in https://github.com/neutron-org/neutron/pull/434 (privileged subdaos). 