### PR TITLE
️fix: load genesis path from config when executue newApp

### DIFF
--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -234,7 +234,8 @@ func (ac appCreator) newApp(
 	chainID := cast.ToString(appOpts.Get(flags.FlagChainID))
 	if chainID == "" {
 		// fallback to genesis chain-id
-		appGenesis, err := tmtypes.GenesisDocFromFile(filepath.Join(homeDir, "config", "genesis.json"))
+		genDocFile := filepath.Join(homeDir, cast.ToString(appOpts.Get("genesis_file")))
+		appGenesis, err := tmtypes.GenesisDocFromFile(genDocFile)
 		if err != nil {
 			panic(err)
 		}
@@ -243,7 +244,7 @@ func (ac appCreator) newApp(
 	}
 
 	return app.New(logger, db, traceStore, true, skipUpgradeHeights,
-		cast.ToString(appOpts.Get(flags.FlagHome)),
+		homeDir,
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
 		ac.encCfg,
 		appOpts,


### PR DESCRIPTION
This PR modifies the path to load the Genesis file to obtain the path from the configuration file to set chain-id when running newApp.

close #457