### PR TITLE
release: v3.0.1 handler to remove discrepancy between osmosis and neutron #NTRN-237

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -29,7 +29,7 @@ import (
 	v044 "github.com/neutron-org/neutron/v3/app/upgrades/v0.4.4"
 	v200 "github.com/neutron-org/neutron/v3/app/upgrades/v2.0.0"
 	v202 "github.com/neutron-org/neutron/v3/app/upgrades/v2.0.2"
-	v300 "github.com/neutron-org/neutron/v3/app/upgrades/v3.0.0"
+	v301 "github.com/neutron-org/neutron/v3/app/upgrades/v3.0.1"
 
 	"github.com/neutron-org/neutron/v3/x/cron"
 
@@ -183,7 +183,7 @@ const (
 )
 
 var (
-	Upgrades = []upgrades.Upgrade{v030.Upgrade, v044.Upgrade, v200.Upgrade, v202.Upgrade, v300.Upgrade}
+	Upgrades = []upgrades.Upgrade{v030.Upgrade, v044.Upgrade, v200.Upgrade, v202.Upgrade, v301.Upgrade}
 
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
@@ -1134,6 +1134,8 @@ func (app *App) setupUpgradeHandlers() {
 				&upgrades.UpgradeKeepers{
 					AccountKeeper:       app.AccountKeeper,
 					FeeBurnerKeeper:     app.FeeBurnerKeeper,
+					BankKeeper:          app.BankKeeper,
+					TransferKeeper:      app.TransferKeeper.Keeper,
 					CronKeeper:          app.CronKeeper,
 					IcqKeeper:           app.InterchainQueriesKeeper,
 					TokenFactoryKeeper:  app.TokenFactoryKeeper,

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -6,6 +6,7 @@ import (
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
@@ -21,6 +22,7 @@ import (
 	tokenfactorykeeper "github.com/neutron-org/neutron/v3/x/tokenfactory/keeper"
 
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	transferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal
@@ -41,6 +43,8 @@ type Upgrade struct {
 type UpgradeKeepers struct {
 	// keepers
 	AccountKeeper      authkeeper.AccountKeeper
+	BankKeeper         bankkeeper.Keeper
+	TransferKeeper     transferkeeper.Keeper
 	IcqKeeper          icqkeeper.Keeper
 	CronKeeper         cronkeeper.Keeper
 	TokenFactoryKeeper *tokenfactorykeeper.Keeper

--- a/app/upgrades/v3.0.1/constants.go
+++ b/app/upgrades/v3.0.1/constants.go
@@ -1,4 +1,4 @@
-package v300
+package v301
 
 import (
 	"cosmossdk.io/math"
@@ -12,10 +12,10 @@ import (
 
 const (
 	// UpgradeName defines the on-chain upgrade name.
-	UpgradeName = "v3.0.0"
+	UpgradeName = "v3.0.1"
 
-	AuctionParamsMaxBundleSize          = 2
-	AuctionParamsFrontRunningProtection = true
+	AuctionParamsMaxBundleSize          = 4
+	AuctionParamsFrontRunningProtection = false
 )
 
 var (

--- a/app/upgrades/v3.0.1/upgrades.go
+++ b/app/upgrades/v3.0.1/upgrades.go
@@ -1,8 +1,10 @@
 package v301
 
 import (
-	"cosmossdk.io/math"
 	"fmt"
+
+	"cosmossdk.io/math"
+
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	transferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"

--- a/app/upgrades/v3.0.1/upgrades.go
+++ b/app/upgrades/v3.0.1/upgrades.go
@@ -26,6 +26,10 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
+// CreateUpgradeHandler is an upgrade major version 2 -> 3
+// Upgrade v3.0.0 was applied on pion-1 chain and later renamed to v3.0.1
+// Upgrade v3.0.1 is in a nutshell the same v3.0.0 but with additional storage migrations
+// specially for neutron-1 chain - setICSParams and removeDiscrepancies
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,

--- a/app/upgrades/v3.0.1/upgrades_test.go
+++ b/app/upgrades/v3.0.1/upgrades_test.go
@@ -1,4 +1,4 @@
-package v300_test
+package v301_test
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/stretchr/testify/require"
 
-	v300 "github.com/neutron-org/neutron/v3/app/upgrades/v3.0.0"
+	v300 "github.com/neutron-org/neutron/v3/app/upgrades/v3.0.1"
 	"github.com/neutron-org/neutron/v3/testutil"
 )
 


### PR DESCRIPTION
Due to a bug in the PFM module, a discrepancy in the balances may happen. Which leads to different amount of tokens between the number of locked tokens in the escrow account of the ibc-transfer module  and the actual number of tokens transferred to a counterparty chain via ibc. This is what happened with the neutron-osmosis pair.

The amount of locked tokens on the neutron network is `10481 ibc/B7864B03E1B9FD4F049243E92ABD691586F682137037A9F3FCA5222815620B3C` (axelar's stAtom)
The actual amount of tokens transferred to osmosis is `2447077 ibc/8FCFAF3AE6BA4C5BDFF85B41449FBACE547E2BAC23895E839230404FB0EC3837`
The bug causing these issues has been fixed in releases v2.0.3 (neutron-1) and v3.0.0 (pion-1). 

In this PR, we are fixing the discrepancy by issuing `2436596 ibc/B7864B03E1B9FD4F049243E92ABD691586F682137037A9F3FCA5222815620B3C` and sending them to the escrow account `neutron1fp9wuhq58pz53wxvv3tnrxkw8m8s6swpf2fkv9` (`neutrond q ibc-transfer escrow-address transfer channel-10`), where `channel-10` is the transfer channel for neutron (`channel-10`) <-> (`channel-874`) osmosis.

To find all discrepancies you can use https://github.com/strangelove-ventures/escrow-checker tool