### PR TITLE
fix: remove default fee in tick update event

### DIFF
--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -189,7 +189,6 @@ func TickUpdateEvent(
 		sdk.NewAttribute(TickUpdateEventToken1, token1),
 		sdk.NewAttribute(TickUpdateEventTokenIn, makerDenom),
 		sdk.NewAttribute(TickUpdateEventTickIndex, strconv.FormatInt(tickIndex, 10)),
-		sdk.NewAttribute(TickUpdateEventFee, strconv.FormatInt(int64(0), 10)),
 		sdk.NewAttribute(TickUpdateEventReserves, reserves.String()),
 	}
 	attrs = append(attrs, otherAttrs...)

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -189,7 +189,7 @@ func TickUpdateEvent(
 		sdk.NewAttribute(TickUpdateEventToken1, token1),
 		sdk.NewAttribute(TickUpdateEventTokenIn, makerDenom),
 		sdk.NewAttribute(TickUpdateEventTickIndex, strconv.FormatInt(tickIndex, 10)),
-		sdk.NewAttribute(TickUpdateEventFee, strconv.FormatInt(tickIndex, 10)),
+		sdk.NewAttribute(TickUpdateEventFee, strconv.FormatInt(int64(0), 10)),
 		sdk.NewAttribute(TickUpdateEventReserves, reserves.String()),
 	}
 	attrs = append(attrs, otherAttrs...)


### PR DESCRIPTION
The default fee attribute here is incorrectly set (it assumes the value of the `TickIndex` which may not be a valid fee at all).

It is better to be removed from the base event and only optionally added on line 208: this helps us distinguish between an intentionally set Fee of `0` and no fee set at all (eg. the tick is reserves in a tranche without a fee as used in line 221).