### PR TITLE
Prevent deposits behind enemy lines

### DIFF
--- a/x/dex/keeper/core.go
+++ b/x/dex/keeper/core.go
@@ -53,6 +53,10 @@ func (k Keeper) DepositCore(
 		if err := k.ValidateFee(ctx, fee); err != nil {
 			return nil, nil, nil, err
 		}
+
+		if k.IsPoolBehindEnemyLines(ctx, pairID, tickIndex, fee, amount0, amount1) {
+			return nil, nil, nil, types.ErrDepositBehindEnemyLines
+		}
 		autoswap := !options[i].DisableAutoswap
 
 		pool, err := k.GetOrInitPool(

--- a/x/dex/keeper/core_helper.go
+++ b/x/dex/keeper/core_helper.go
@@ -8,6 +8,7 @@ import (
 
 	math_utils "github.com/neutron-org/neutron/v3/utils/math"
 	"github.com/neutron-org/neutron/v3/x/dex/types"
+	"github.com/neutron-org/neutron/v3/x/dex/utils"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -72,6 +73,37 @@ func (k Keeper) ValidateFee(ctx sdk.Context, fee uint64) error {
 	}
 
 	return nil
+}
+
+func (k Keeper) IsBehindEnemyLines(ctx sdk.Context, tradePairID *types.TradePairID, tickIndex int64) bool {
+	opTradePairId := tradePairID.Reversed()
+	oppositeTick, found := k.GetCurrTickIndexTakerToMaker(ctx, opTradePairId)
+
+	if found && tickIndex*-1 > oppositeTick {
+		return true
+	}
+
+	return false
+}
+
+func (k Keeper) IsPoolBehindEnemyLines(ctx sdk.Context, pairID *types.PairID, tickIndex int64, fee uint64, amount0, amount1 math.Int) bool {
+	if amount0.IsPositive() {
+		tradePairID0 := types.NewTradePairIDFromMaker(pairID, pairID.Token0)
+		tick0 := tickIndex*-1 + utils.MustSafeUint64ToInt64(fee)
+		if k.IsBehindEnemyLines(ctx, tradePairID0, tick0) {
+			return true
+		}
+	}
+
+	if amount1.IsPositive() {
+		tradePairID1 := types.NewTradePairIDFromMaker(pairID, pairID.Token1)
+		tick1 := tickIndex + utils.MustSafeUint64ToInt64(fee)
+		if k.IsBehindEnemyLines(ctx, tradePairID1, tick1) {
+			return true
+		}
+	}
+
+	return false
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/x/dex/keeper/core_helper.go
+++ b/x/dex/keeper/core_helper.go
@@ -76,8 +76,7 @@ func (k Keeper) ValidateFee(ctx sdk.Context, fee uint64) error {
 }
 
 func (k Keeper) IsBehindEnemyLines(ctx sdk.Context, tradePairID *types.TradePairID, tickIndex int64) bool {
-	opTradePairId := tradePairID.Reversed()
-	oppositeTick, found := k.GetCurrTickIndexTakerToMaker(ctx, opTradePairId)
+	oppositeTick, found := k.GetCurrTickIndexTakerToMaker(ctx, tradePairID.Reversed())
 
 	if found && tickIndex*-1 > oppositeTick {
 		return true

--- a/x/dex/keeper/core_helper_test.go
+++ b/x/dex/keeper/core_helper_test.go
@@ -144,3 +144,104 @@ func (s *CoreHelpersTestSuite) TestGetCurrTick0To1WithMinLiq() {
 	s.Require().True(found)
 	s.Assert().Equal(int64(2), tickIdx)
 }
+
+// IsBehindEnemyLines /////////////////////////////////////////////////////////
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0BELHighTick() {
+	s.setLPAtFee1Pool(100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -102)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0BELLowTick() {
+	s.setLPAtFee1Pool(-100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 98)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0ValidHighTick() {
+	s.setLPAtFee1Pool(100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -101)
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0ValidLowtick() {
+	s.setLPAtFee1Pool(-100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 99)
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1BELLowTick() {
+	s.setLPAtFee1Pool(-10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -12)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1BELHighTick() {
+	s.setLPAtFee1Pool(10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 8)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1ValidLowTick() {
+	s.setLPAtFee1Pool(-10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -11)
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1ValidHighTick() {
+	s.setLPAtFee1Pool(10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 9)
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsPoolBehindEnemyLinesToken0BEL() {
+	// GIVEN Token1 at tick -19
+	s.setLPAtFee1Pool(-20, 0, 10)
+
+	// WHEN create pool with token0 at 18
+	isBEL := s.app.DexKeeper.IsPoolBehindEnemyLines(s.ctx, defaultPairID, -17, 1, math.OneInt(), math.ZeroInt())
+
+	// THEN pool is BEL
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsPoolBehindEnemyLinesToken0Valid() {
+	// GIVEN Token1 at tick -19
+	s.setLPAtFee1Pool(-20, 0, 10)
+
+	// WHEN create pool with token0 at 19
+	isBEL := s.app.DexKeeper.IsPoolBehindEnemyLines(s.ctx, defaultPairID, -18, 1, math.OneInt(), math.ZeroInt())
+	// THEN pool is not BEL
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsPoolBehindEnemyLinesToken1BEL() {
+	// GIVEN token0 at -19
+	s.setLPAtFee1Pool(20, 10, 0)
+
+	// WHEN create pool with Token1 at 18
+	isBEL := s.app.DexKeeper.IsPoolBehindEnemyLines(s.ctx, defaultPairID, 17, 1, math.ZeroInt(), math.OneInt())
+
+	// THEN pool is BEL
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsPoolBehindEnemyLinesToken1Valid() {
+	// GIVEN token0 at -19
+	s.setLPAtFee1Pool(20, 10, 0)
+
+	// WHEN create pool with Token1 at 19
+	isBEL := s.app.DexKeeper.IsPoolBehindEnemyLines(s.ctx, defaultPairID, 18, 1, math.ZeroInt(), math.OneInt())
+
+	// THEN pool is BEL
+	s.False(isBEL)
+}

--- a/x/dex/keeper/integration_deposit_doublesided_test.go
+++ b/x/dex/keeper/integration_deposit_doublesided_test.go
@@ -98,50 +98,6 @@ func (s *DexTestSuite) TestDepositDoubleSidedHalfInSpreadCurrTick1To0Adjusted() 
 	s.assertCurr0To1(4)
 }
 
-func (s *DexTestSuite) TestDepositDoubleSidedCreatingArbBelow() {
-	s.fundAliceBalances(50, 50)
-	s.fundBobBalances(50, 50)
-
-	// GIVEN
-	// deposit 10 of token A at tick 0 fee 1
-	s.aliceDeposits(NewDeposit(10, 0, 0, 1))
-	s.assertAliceBalances(40, 50)
-	s.assertDexBalances(10, 0)
-	s.assertPoolLiquidity(10, 0, 0, 1)
-
-	// WHEN
-	// depositing below enemy lines at tick -5
-	// THEN
-	// deposit should not fail with BEL error, balances and liquidity should not change at deposited tick
-
-	s.aliceDeposits(NewDeposit(10, 11, -5, 1))
-
-	// buying liquidity behind enemy lines doesn't break anything
-	s.bobLimitSells("TokenA", 0, 10, types.LimitOrderType_FILL_OR_KILL)
-}
-
-func (s *DexTestSuite) TestDepositDoubleSidedCreatingArbAbove() {
-	s.fundAliceBalances(50, 50)
-	s.fundBobBalances(50, 50)
-
-	// GIVEN
-	// deposit 10 of token A at tick 0 fee 1
-	s.aliceDeposits(NewDeposit(0, 10, 0, 1))
-	s.assertAliceBalances(50, 40)
-	s.assertDexBalances(0, 10)
-	s.assertPoolLiquidity(0, 10, 0, 1)
-
-	// WHEN
-	// depositing above enemy lines at tick 5
-	// THEN
-	// deposit should not fail with BEL error, balances and liquidity should not change at deposited tick
-
-	s.aliceDeposits(NewDeposit(11, 10, 5, 1))
-
-	// buying liquidity behind enemy lines doesn't break anything
-	s.bobLimitSells("TokenB", 0, 10, types.LimitOrderType_FILL_OR_KILL)
-}
-
 func (s *DexTestSuite) TestDepositDoubleSidedFirstSharesMintedTotal() {
 	s.fundAliceBalances(50, 50)
 

--- a/x/dex/keeper/integration_deposit_multi_test.go
+++ b/x/dex/keeper/integration_deposit_multi_test.go
@@ -23,6 +23,25 @@ func (s *DexTestSuite) TestDepositMultiCompleteFailure() {
 	)
 }
 
+func (s *DexTestSuite) TestDepositMultiPartialBELFailure() {
+	s.fundAliceBalances(50, 50)
+
+	// GIVEN
+	// no existing liquidity
+
+	// WHEN
+	// alice deposits 5 A, 5 B at tick 0 and 5 A at tick -2
+	// THEN
+	// second deposit fails BEL check
+
+	err := types.ErrDepositBehindEnemyLines
+	s.assertAliceDepositFails(
+		err,
+		NewDeposit(5, 5, 0, 1),
+		NewDeposit(5, 0, 3, 1),
+	)
+}
+
 func (s *DexTestSuite) TestDepositMultiSuccess() {
 	s.fundAliceBalances(50, 50)
 
@@ -30,16 +49,18 @@ func (s *DexTestSuite) TestDepositMultiSuccess() {
 	// no existing liquidity
 
 	// WHEN
-	// alice deposits 5 A, 5 B at tick 0 fee 0 and then 10 A, 10 B at tick 5 fee 0
+	// alice deposits 5 A, 5 B at tick 0, 5 A at tick -5 and 5 B at tick 5
 	s.aliceDeposits(
 		NewDeposit(5, 5, 0, 1),
-		NewDeposit(10, 10, 5, 0),
+		NewDeposit(5, 0, -6, 1),
+		NewDeposit(0, 5, 4, 1),
 	)
 
 	// THEN
 	// both deposits should go through
-	s.assertAliceBalances(35, 35)
+	s.assertAliceBalances(40, 40)
 	s.assertLiquidityAtTick(5, 5, 0, 1)
-	s.assertLiquidityAtTick(10, 10, 5, 0)
-	s.assertDexBalances(15, 15)
+	s.assertLiquidityAtTick(5, 0, -6, 1)
+	s.assertLiquidityAtTick(0, 5, 4, 1)
+	s.assertDexBalances(10, 10)
 }

--- a/x/dex/keeper/integration_deposit_singlesided_test.go
+++ b/x/dex/keeper/integration_deposit_singlesided_test.go
@@ -387,7 +387,6 @@ func (s *DexTestSuite) TestDepositSingleInvalidFeeFails() {
 }
 
 func (s *DexTestSuite) TestDepositSingleToken0BELFails() {
-
 	s.fundAliceBalances(50, 50)
 
 	// GIVEN TokenB liquidity at tick 2002-2004
@@ -404,7 +403,6 @@ func (s *DexTestSuite) TestDepositSingleToken0BELFails() {
 }
 
 func (s *DexTestSuite) TestDepositSingleToken1BELFails() {
-
 	s.fundAliceBalances(50, 50)
 
 	// GIVEN TokenA liquidity at tick 2002-2005

--- a/x/dex/keeper/msg_server_test.go
+++ b/x/dex/keeper/msg_server_test.go
@@ -672,7 +672,6 @@ func (s *DexTestSuite) assertDepositFails(
 		Fees:            fees,
 		Options:         options,
 	})
-	s.Assert().NotNil(err)
 	s.Assert().ErrorIs(err, expectedErr)
 }
 

--- a/x/dex/types/errors.go
+++ b/x/dex/types/errors.go
@@ -189,4 +189,9 @@ var (
 		1154,
 		"Swap amount too small; creates unfair spread for liquidity providers",
 	)
+	ErrDepositBehindEnemyLines = sdkerrors.Register(
+		ModuleName,
+		1155,
+		"Cannot deposit at a price below the opposing token's current price",
+	)
 )


### PR DESCRIPTION
Prevent users from depositing liquidity at price cheaper than the cheapest opposing liquidity is being sold for. 
Being able to do so introduces a DOS vector since below market price ticks can be filled with dust resulting in very expensive swaps. 
This change will be reverted once full auto-swap for deposits is added. 