### PR TITLE
Feat: enable vote extensions in upgrade handler

### DIFF
--- a/app/upgrades/v4.0.0/upgrades.go
+++ b/app/upgrades/v4.0.0/upgrades.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	comettypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	adminmoduletypes "github.com/cosmos/admin-module/x/adminmodule/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
+	"github.com/cosmos/cosmos-sdk/x/consensus/types"
 
 	marketmapkeeper "github.com/skip-mev/slinky/x/marketmap/keeper"
 	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
@@ -40,6 +43,12 @@ func CreateUpgradeHandler(
 			return nil, err
 		}
 
+		ctx.Logger().Info("Setting consensus params...")
+		err = enableVoteExtensions(ctx, keepers.ConsensusKeeper)
+		if err != nil {
+			return nil, err
+		}
+
 		ctx.Logger().Info(fmt.Sprintf("Migration {%s} applied", UpgradeName))
 		return vm, nil
 	}
@@ -56,4 +65,25 @@ func setMarketMapParams(ctx sdk.Context, marketmapKeeper *marketmapkeeper.Keeper
 		Version:         params.Version,
 	}
 	return marketmapKeeper.SetParams(ctx, marketmapParams)
+}
+
+func enableVoteExtensions(ctx sdk.Context, consensusKeeper *consensuskeeper.Keeper) error {
+	oldParams, err := consensusKeeper.Params(ctx, &types.QueryParamsRequest{})
+	if err != nil {
+		return err
+	}
+
+	// we need to enable VoteExtensions for Slinky
+	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight()}
+
+	updateParamsMsg := types.MsgUpdateParams{
+		Authority: authtypes.NewModuleAddress(adminmoduletypes.ModuleName).String(),
+		Block:     oldParams.Params.Block,
+		Evidence:  oldParams.Params.Evidence,
+		Validator: oldParams.Params.Validator,
+		Abci:      oldParams.Params.Abci,
+	}
+
+	_, err = consensusKeeper.UpdateParams(ctx, &updateParamsMsg)
+	return err
 }

--- a/app/upgrades/v4.0.0/upgrades.go
+++ b/app/upgrades/v4.0.0/upgrades.go
@@ -74,7 +74,7 @@ func enableVoteExtensions(ctx sdk.Context, consensusKeeper *consensuskeeper.Keep
 	}
 
 	// we need to enable VoteExtensions for Slinky
-	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight()}
+	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight() + 4}
 
 	updateParamsMsg := types.MsgUpdateParams{
 		Authority: authtypes.NewModuleAddress(adminmoduletypes.ModuleName).String(),

--- a/app/upgrades/v4.0.0/upgrades_test.go
+++ b/app/upgrades/v4.0.0/upgrades_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	comettypes "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/x/consensus/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/suite"
@@ -40,4 +42,31 @@ func (suite *UpgradeTestSuite) TestOracleUpgrade() {
 	suite.Require().NoError(err)
 	suite.Require().Equal(params.MarketAuthority, "neutron1hxskfdxpp5hqgtjj6am6nkjefhfzj359x0ar3z")
 	suite.Require().Equal(params.Version, uint64(0))
+}
+
+func (suite *UpgradeTestSuite) TestEnableVoteExtensionsUpgrade() {
+	app := suite.GetNeutronZoneApp(suite.ChainA)
+	ctx := suite.ChainA.GetContext()
+	t := suite.T()
+
+	oldParams, err := app.ConsensusParamsKeeper.Params(ctx, &types.QueryParamsRequest{})
+	suite.Require().NoError(err)
+
+	// VoteExtensionsEnableHeight must be updated after the upgrade on upgrade height
+	// but the rest of params must be the same
+	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight()}
+	// it is automatically tracked in upgrade handler, we need to set it manually for tests
+	oldParams.Params.Version = &comettypes.VersionParams{App: 0}
+
+	upgrade := upgradetypes.Plan{
+		Name:   v400.UpgradeName,
+		Info:   "some text here",
+		Height: ctx.BlockHeight(),
+	}
+	require.NoError(t, app.UpgradeKeeper.ApplyUpgrade(ctx, upgrade))
+
+	newParams, err := app.ConsensusParamsKeeper.Params(ctx, &types.QueryParamsRequest{})
+	suite.Require().NoError(err)
+
+	suite.Require().Equal(oldParams, newParams)
 }

--- a/app/upgrades/v4.0.0/upgrades_test.go
+++ b/app/upgrades/v4.0.0/upgrades_test.go
@@ -54,7 +54,7 @@ func (suite *UpgradeTestSuite) TestEnableVoteExtensionsUpgrade() {
 
 	// VoteExtensionsEnableHeight must be updated after the upgrade on upgrade height
 	// but the rest of params must be the same
-	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight()+4}
+	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight() + 4}
 	// it is automatically tracked in upgrade handler, we need to set it manually for tests
 	oldParams.Params.Version = &comettypes.VersionParams{App: 0}
 

--- a/app/upgrades/v4.0.0/upgrades_test.go
+++ b/app/upgrades/v4.0.0/upgrades_test.go
@@ -54,7 +54,7 @@ func (suite *UpgradeTestSuite) TestEnableVoteExtensionsUpgrade() {
 
 	// VoteExtensionsEnableHeight must be updated after the upgrade on upgrade height
 	// but the rest of params must be the same
-	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight()}
+	oldParams.Params.Abci = &comettypes.ABCIParams{VoteExtensionsEnableHeight: ctx.BlockHeight()+4}
 	// it is automatically tracked in upgrade handler, we need to set it manually for tests
 	oldParams.Params.Version = &comettypes.VersionParams{App: 0}
 


### PR DESCRIPTION
This PR adds a simple method to enable Vote Extensions functionality (Slinky requires it) in v4 upgrade handler