### PR TITLE
Fix: bring back lost CLI commands

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -10,6 +10,11 @@ import (
 	"path/filepath"
 	"time"
 
+	"cosmossdk.io/client/v2/autocli"
+	"cosmossdk.io/core/appmodule"
+	"github.com/cosmos/cosmos-sdk/runtime/services"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+
 	appconfig "github.com/neutron-org/neutron/v4/app/config"
 
 	"github.com/skip-mev/slinky/x/oracle"
@@ -1325,6 +1330,26 @@ func (app *App) setupUpgradeHandlers() {
 				app.AppCodec(),
 			),
 		)
+	}
+}
+
+func (app *App) AutoCliOpts() autocli.AppOptions {
+	modules := make(map[string]appmodule.AppModule, 0)
+	for _, m := range app.mm.Modules {
+		if moduleWithName, ok := m.(module.HasName); ok {
+			moduleName := moduleWithName.Name()
+			if appModule, ok := moduleWithName.(appmodule.AppModule); ok {
+				modules[moduleName] = appModule
+			}
+		}
+	}
+
+	return autocli.AppOptions{
+		Modules:               modules,
+		ModuleOptions:         services.ExtractAutoCLIOptions(app.mm.Modules),
+		AddressCodec:          authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
+		ValidatorAddressCodec: authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
+		ConsensusAddressCodec: authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
 	}
 }
 

--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -63,7 +63,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		app.DefaultNodeHome,
 		0,
 		encodingConfig,
-		sims.NewAppOptionsWithFlagHome(tempDir()),
+		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
 		nil,
 	)
 
@@ -367,14 +367,4 @@ func setCustomEnvVariablesFromClientToml(ctx client.Context) {
 	setEnvFromConfig("fee-account", "NEUTROND_FEE_ACCOUNT")
 	// memo
 	setEnvFromConfig("note", "NEUTROND_NOTE")
-}
-
-var tempDir = func() string {
-	dir, err := os.MkdirTemp("", "simapp")
-	if err != nil {
-		dir = app.DefaultNodeHome
-	}
-	defer os.RemoveAll(dir)
-
-	return dir
 }

--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -154,6 +154,9 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	// add keybase, auxiliary RPC, query, and tx child commands
 	rootCmd.AddCommand(
 		server.StatusCommand(),
+		server.ShowValidatorCmd(),
+		server.ShowNodeIDCmd(),
+		server.ShowAddressCmd(),
 		queryCommand(),
 		txCommand(),
 		keys.Commands(),
@@ -176,14 +179,14 @@ func queryCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		// TODO: authcmd.GetAccountCmd(),
 		rpc.ValidatorCommand(),
-		// TODO: rpc.BlockCommand(),
+		server.QueryBlockResultsCmd(),
+		server.QueryBlocksCmd(),
+		server.QueryBlockCmd(),
 		authcmd.QueryTxsByEventsCmd(),
 		authcmd.QueryTxCmd(),
 	)
 
-	app.ModuleBasics.AddQueryCommands(cmd)
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
 
 	return cmd
@@ -210,7 +213,6 @@ func txCommand() *cobra.Command {
 		authcmd.GetDecodeCommand(),
 	)
 
-	app.ModuleBasics.AddTxCommands(cmd)
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
 
 	return cmd


### PR DESCRIPTION
This PR brings back all lost CLI commands which were lost during SDK 0.47 -> 0.50 upgrade because of [AutoCLI](https://docs.cosmos.network/main/learn/advanced/autocli) feature.

Moving Neutron's modules logic to autocli is out of scope of this PR