### PR TITLE
fix: use basicmodulemanager as recommended in sdk-50 upgrade guide

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -127,6 +127,7 @@ import (
 	ibchost "github.com/cosmos/ibc-go/v8/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
+
 	"github.com/spf13/cast"
 
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
@@ -938,6 +939,8 @@ func New(
 					adminmodulecli.NewCmdSubmitCancelUpgradeProposal,
 				),
 			),
+			// Manually register the transfer module since we dont use a native ibc-go transfer module but a custom implementation
+			ibctransfertypes.ModuleName: transferSudo.AppModuleBasic{},
 		},
 	)
 	app.BasicModuleManager.RegisterLegacyAminoCodec(encodingConfig.Amino)

--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	tendermint "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 	"io"
 	"io/fs"
 	"net/http"
@@ -246,17 +247,6 @@ var (
 	// 	feeburner.AppModuleBasic{},
 	// 	contractmanager.AppModuleBasic{},
 	// 	cron.AppModuleBasic{},
-	// 	adminmodule.NewAppModuleBasic(
-	// 		govclient.NewProposalHandler(
-	// 			adminmodulecli.NewSubmitParamChangeProposalTxCmd,
-	// 		),
-	// 		govclient.NewProposalHandler(
-	// 			adminmodulecli.NewCmdSubmitUpgradeProposal,
-	// 		),
-	// 		govclient.NewProposalHandler(
-	// 			adminmodulecli.NewCmdSubmitCancelUpgradeProposal,
-	// 		),
-	// 	),
 	// 	ibchooks.AppModuleBasic{},
 	// 	packetforward.AppModuleBasic{},
 	// 	auction.AppModuleBasic{},
@@ -897,6 +887,7 @@ func New(
 		evidence.NewAppModule(app.EvidenceKeeper),
 		ibc.NewAppModule(app.IBCKeeper),
 		params.NewAppModule(app.ParamsKeeper),
+		tendermint.NewAppModule(),
 		transferModule,
 		consumerModule,
 		icaModule,

--- a/app/app.go
+++ b/app/app.go
@@ -45,9 +45,6 @@ import (
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
-	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-	tendermint "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 
 	"github.com/neutron-org/neutron/v4/docs"
 
@@ -99,6 +96,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -142,7 +142,6 @@ import (
 	adminmodulecli "github.com/cosmos/admin-module/x/adminmodule/client/cli"
 	adminmodulekeeper "github.com/cosmos/admin-module/x/adminmodule/keeper"
 	adminmoduletypes "github.com/cosmos/admin-module/x/adminmodule/types"
-	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	appparams "github.com/neutron-org/neutron/v4/app/params"
@@ -220,52 +219,52 @@ var (
 	// ModuleBasics defines the module BasicManager is in charge of setting up basic,
 	// non-dependant module elements, such as codec registration
 	// and genesis verification.
-	ModuleBasics = module.NewBasicManager(
-		auth.AppModuleBasic{},
-		authzmodule.AppModuleBasic{},
-		bank.AppModuleBasic{},
-		capability.AppModuleBasic{},
-		genutil.NewAppModuleBasic(genutiltypes.DefaultMessageValidator),
-		params.AppModuleBasic{},
-		crisis.AppModuleBasic{},
-		slashing.AppModuleBasic{},
-		feegrantmodule.AppModuleBasic{},
-		ibc.AppModuleBasic{},
-		ica.AppModuleBasic{},
-		tendermint.AppModuleBasic{},
-		upgrade.AppModuleBasic{},
-		evidence.AppModuleBasic{},
-		transferSudo.AppModuleBasic{},
-		vesting.AppModuleBasic{},
-		ccvconsumer.AppModuleBasic{},
-		wasm.AppModuleBasic{},
-		tokenfactory.AppModuleBasic{},
-		interchainqueries.AppModuleBasic{},
-		interchaintxs.AppModuleBasic{},
-		feerefunder.AppModuleBasic{},
-		feeburner.AppModuleBasic{},
-		contractmanager.AppModuleBasic{},
-		cron.AppModuleBasic{},
-		adminmodule.NewAppModuleBasic(
-			govclient.NewProposalHandler(
-				adminmodulecli.NewSubmitParamChangeProposalTxCmd,
-			),
-			govclient.NewProposalHandler(
-				adminmodulecli.NewCmdSubmitUpgradeProposal,
-			),
-			govclient.NewProposalHandler(
-				adminmodulecli.NewCmdSubmitCancelUpgradeProposal,
-			),
-		),
-		ibchooks.AppModuleBasic{},
-		packetforward.AppModuleBasic{},
-		auction.AppModuleBasic{},
-		globalfee.AppModule{},
-		dex.AppModuleBasic{},
-		ibcswap.AppModuleBasic{},
-		oracle.AppModuleBasic{},
-		marketmap.AppModuleBasic{},
-	)
+	// ModuleBasics = module.NewBasicManager(
+	// 	auth.AppModuleBasic{},
+	// 	authzmodule.AppModuleBasic{},
+	// 	bank.AppModuleBasic{},
+	// 	capability.AppModuleBasic{},
+	// 	genutil.NewAppModuleBasic(genutiltypes.DefaultMessageValidator),
+	// 	params.AppModuleBasic{},
+	// 	crisis.AppModuleBasic{},
+	// 	slashing.AppModuleBasic{},
+	// 	feegrantmodule.AppModuleBasic{},
+	// 	ibc.AppModuleBasic{},
+	// 	ica.AppModuleBasic{},
+	// 	tendermint.AppModuleBasic{},
+	// 	upgrade.AppModuleBasic{},
+	// 	evidence.AppModuleBasic{},
+	// 	transferSudo.AppModuleBasic{},
+	// 	vesting.AppModuleBasic{},
+	// 	ccvconsumer.AppModuleBasic{},
+	// 	wasm.AppModuleBasic{},
+	// 	tokenfactory.AppModuleBasic{},
+	// 	interchainqueries.AppModuleBasic{},
+	// 	interchaintxs.AppModuleBasic{},
+	// 	feerefunder.AppModuleBasic{},
+	// 	feeburner.AppModuleBasic{},
+	// 	contractmanager.AppModuleBasic{},
+	// 	cron.AppModuleBasic{},
+	// 	adminmodule.NewAppModuleBasic(
+	// 		govclient.NewProposalHandler(
+	// 			adminmodulecli.NewSubmitParamChangeProposalTxCmd,
+	// 		),
+	// 		govclient.NewProposalHandler(
+	// 			adminmodulecli.NewCmdSubmitUpgradeProposal,
+	// 		),
+	// 		govclient.NewProposalHandler(
+	// 			adminmodulecli.NewCmdSubmitCancelUpgradeProposal,
+	// 		),
+	// 	),
+	// 	ibchooks.AppModuleBasic{},
+	// 	packetforward.AppModuleBasic{},
+	// 	auction.AppModuleBasic{},
+	// 	globalfee.AppModule{},
+	// 	dex.AppModuleBasic{},
+	// 	ibcswap.AppModuleBasic{},
+	// 	oracle.AppModuleBasic{},
+	// 	marketmap.AppModuleBasic{},
+	// )
 
 	// module account permissions
 	maccPerms = map[string][]string{
@@ -382,7 +381,8 @@ type App struct {
 	oracleClient oracleclient.OracleClient
 
 	// mm is the module manager
-	mm *module.Manager
+	mm                 *module.Manager
+	BasicModuleManager module.BasicManager
 
 	// sm is the simulation manager
 	sm *module.SimulationManager
@@ -417,12 +417,12 @@ func New(
 	skipUpgradeHeights map[int64]bool,
 	homePath string,
 	invCheckPeriod uint,
-	encodingConfig appparams.EncodingConfig,
 	appOpts servertypes.AppOptions,
 	wasmOpts []wasmkeeper.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
 	overrideWasmVariables()
+	encodingConfig := MakeEncodingConfig()
 
 	appCodec := encodingConfig.Marshaler
 	legacyAmino := encodingConfig.Amino
@@ -917,6 +917,34 @@ func New(
 		auction.NewAppModule(appCodec, app.AuctionKeeper),
 		// always be last to make sure that it checks for all invariants and not only part of them
 		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
+	)
+
+	// BasicModuleManager defines the module BasicManager is in charge of setting up basic,
+	// non-dependant module elements, such as codec registration and genesis verification.
+	// By default it is composed of all the module from the module manager.
+	// Additionally, app module basics can be overwritten by passing them as argument.
+	app.BasicModuleManager = module.NewBasicManagerFromManager(
+		app.mm,
+		map[string]module.AppModuleBasic{
+			genutiltypes.ModuleName: genutil.NewAppModuleBasic(genutiltypes.DefaultMessageValidator),
+			adminmoduletypes.ModuleName: adminmodule.NewAppModuleBasic(
+				govclient.NewProposalHandler(
+					adminmodulecli.NewSubmitParamChangeProposalTxCmd,
+				),
+				govclient.NewProposalHandler(
+					adminmodulecli.NewCmdSubmitUpgradeProposal,
+				),
+				govclient.NewProposalHandler(
+					adminmodulecli.NewCmdSubmitCancelUpgradeProposal,
+				),
+			),
+		},
+	)
+	app.BasicModuleManager.RegisterLegacyAminoCodec(encodingConfig.Amino)
+	app.BasicModuleManager.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
+	app.mm.SetOrderPreBlockers(
+		upgradetypes.ModuleName,
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -1509,7 +1537,7 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig
 	// Register new tendermint queries routes from grpc-gateway.
 	cmtservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
-	ModuleBasics.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
+	app.BasicModuleManager.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
 	// Register app's swagger ui
 	if apiConfig.Swagger {

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -11,7 +11,5 @@ func MakeEncodingConfig() params.EncodingConfig {
 	encodingConfig := params.MakeEncodingConfig()
 	std.RegisterLegacyAminoCodec(encodingConfig.Amino)
 	std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-	ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	return encodingConfig
 }

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"encoding/json"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 // GenesisState is the genesis state of the blockchain represented here as a map of raw json
@@ -16,13 +14,13 @@ import (
 type GenesisState map[string]json.RawMessage
 
 // NewDefaultGenesisState generates the default state for the application.
-func NewDefaultGenesisState(cdc codec.JSONCodec) GenesisState {
+func (app *App) NewDefaultGenesisState() GenesisState {
 	// This ugly hack is required to alter globalfee module genesis state
 	// because in current chain implementation staking module is absent which is required by globalfee module
 	// and we can't use default genesis state for globalfee module.
 	// If we do not alter globalfee module genesis state, then we will get panic during tests run.
 
-	genesisState := ModuleBasics.DefaultGenesis(cdc)
+	genesisState := app.BasicModuleManager.DefaultGenesis(app.appCodec)
 	// globalFeeGenesisState := globalfeetypes.GenesisState{
 	//	Params: globalfeetypes.Params{
 	//		MinimumGasPrices: sdk.DecCoins{

--- a/app/params/encoding.go
+++ b/app/params/encoding.go
@@ -37,6 +37,11 @@ func MakeEncodingConfig() EncodingConfig {
 	if err != nil {
 		panic(err)
 	}
+
+	if err := reg.SigningContext().Validate(); err != nil {
+		panic(err)
+	}
+
 	marshaler := codec.NewProtoCodec(reg)
 	txCfg := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
 

--- a/testutil/contractmanager/network/network.go
+++ b/testutil/contractmanager/network/network.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"cosmossdk.io/log"
 	pruningtypes "cosmossdk.io/store/pruning/types"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
-	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -72,12 +72,13 @@ func DefaultConfig() network.Config {
 		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
 		nil,
 	)
+	encoding := app.MakeEncodingConfig()
 
 	// app doesn't have these modules anymore, but we need them for test setup, which uses gentx and MsgCreateValidator
-	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
-	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModuleBasic{}
+	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModule{}
+	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModule{}
+	tempApp.BasicModuleManager.RegisterInterfaces(encoding.InterfaceRegistry)
 
-	encoding := app.MakeEncodingConfig()
 	chainID := "chain-" + tmrand.NewRand().Str(6)
 	return network.Config{
 		Codec:             encoding.Marshaler,

--- a/testutil/contractmanager/network/network.go
+++ b/testutil/contractmanager/network/network.go
@@ -8,6 +8,7 @@ import (
 	db "github.com/cosmos/cosmos-db"
 	"github.com/stretchr/testify/require"
 
+	"cosmossdk.io/log"
 	pruningtypes "cosmossdk.io/store/pruning/types"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -55,9 +56,26 @@ func New(t *testing.T, configs ...network.Config) *network.Network {
 // DefaultConfig will initialize config for the network with custom application,
 // genesis and single validator. All other parameters are inherited from cosmos-sdk/testutil/network.DefaultConfig
 func DefaultConfig() network.Config {
+	memoryDB := db.NewMemDB()
+
+	// TODO: move to depinject
+	// we "pre"-instantiate the application for getting the injected/configured encoding configuration
+	// note, this is not necessary when using app wiring, as depinject can be directly used
+	tempApp := app.New(
+		log.NewNopLogger(),
+		memoryDB,
+		nil,
+		false,
+		map[int64]bool{},
+		app.DefaultNodeHome,
+		0,
+		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
+		nil,
+	)
+
 	// app doesn't have these modules anymore, but we need them for test setup, which uses gentx and MsgCreateValidator
-	app.ModuleBasics[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
-	app.ModuleBasics[stakingtypes.ModuleName] = staking.AppModuleBasic{}
+	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
+	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModuleBasic{}
 
 	encoding := app.MakeEncodingConfig()
 	chainID := "chain-" + tmrand.NewRand().Str(6)
@@ -79,7 +97,6 @@ func DefaultConfig() network.Config {
 
 			return app.New(
 				val.GetCtx().Logger, db.NewMemDB(), nil, true, map[int64]bool{}, val.GetCtx().Config.RootDir, 0,
-				encoding,
 				sims.EmptyAppOptions{},
 				nil,
 				baseapp.SetPruning(pruningtypes.NewPruningOptionsFromString(val.GetAppConfig().Pruning)),
@@ -87,7 +104,7 @@ func DefaultConfig() network.Config {
 				baseapp.SetChainID(chainID),
 			)
 		},
-		GenesisState:  app.ModuleBasics.DefaultGenesis(encoding.Marshaler),
+		GenesisState:  tempApp.BasicModuleManager.DefaultGenesis(encoding.Marshaler),
 		TimeoutCommit: 2 * time.Second,
 		ChainID:       chainID,
 		// Some changes are introduced to make the tests run as if neutron is a standalone chain.

--- a/testutil/cron/network/network.go
+++ b/testutil/cron/network/network.go
@@ -80,12 +80,13 @@ func DefaultConfig() network.Config {
 		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
 		nil,
 	)
+	encoding := app.MakeEncodingConfig()
 
 	// app doesn't have these modules anymore, but we need them for test setup, which uses gentx and MsgCreateValidator
-	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
-	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModuleBasic{}
+	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModule{}
+	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModule{}
+	tempApp.BasicModuleManager.RegisterInterfaces(encoding.InterfaceRegistry)
 
-	encoding := app.MakeEncodingConfig()
 	chainID := "chain-" + tmrand.NewRand().Str(6)
 	return network.Config{
 		Codec:             encoding.Marshaler,

--- a/testutil/interchainqueries/network/network.go
+++ b/testutil/interchainqueries/network/network.go
@@ -72,12 +72,13 @@ func DefaultConfig() network.Config {
 		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
 		nil,
 	)
+	encoding := app.MakeEncodingConfig()
 
 	// app doesn't have these modules anymore, but we need them for test setup, which uses gentx and MsgCreateValidator
-	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
-	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModuleBasic{}
+	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModule{}
+	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModule{}
+	tempApp.BasicModuleManager.RegisterInterfaces(encoding.InterfaceRegistry)
 
-	encoding := app.MakeEncodingConfig()
 	chainID := "chain-" + tmrand.NewRand().Str(6)
 	return network.Config{
 		Codec:             encoding.Marshaler,

--- a/testutil/interchainqueries/network/network.go
+++ b/testutil/interchainqueries/network/network.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/log"
 	pruningtypes "cosmossdk.io/store/pruning/types"
 	db "github.com/cosmos/cosmos-db"
 	"github.com/stretchr/testify/require"
@@ -55,9 +56,26 @@ func New(t *testing.T, configs ...network.Config) *network.Network {
 // DefaultConfig will initialize config for the network with custom application,
 // genesis and single validator. All other parameters are inherited from cosmos-sdk/testutil/network.DefaultConfig
 func DefaultConfig() network.Config {
+	memoryDB := db.NewMemDB()
+
+	// TODO: move to depinject
+	// we "pre"-instantiate the application for getting the injected/configured encoding configuration
+	// note, this is not necessary when using app wiring, as depinject can be directly used
+	tempApp := app.New(
+		log.NewNopLogger(),
+		memoryDB,
+		nil,
+		false,
+		map[int64]bool{},
+		app.DefaultNodeHome,
+		0,
+		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
+		nil,
+	)
+
 	// app doesn't have these modules anymore, but we need them for test setup, which uses gentx and MsgCreateValidator
-	app.ModuleBasics[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
-	app.ModuleBasics[stakingtypes.ModuleName] = staking.AppModuleBasic{}
+	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
+	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModuleBasic{}
 
 	encoding := app.MakeEncodingConfig()
 	chainID := "chain-" + tmrand.NewRand().Str(6)
@@ -75,7 +93,6 @@ func DefaultConfig() network.Config {
 
 			return app.New(
 				val.GetCtx().Logger, db.NewMemDB(), nil, true, map[int64]bool{}, val.GetCtx().Config.RootDir, 0,
-				encoding,
 				sims.EmptyAppOptions{},
 				nil,
 				baseapp.SetPruning(pruningtypes.NewPruningOptionsFromString(val.GetAppConfig().Pruning)),
@@ -83,7 +100,7 @@ func DefaultConfig() network.Config {
 				baseapp.SetChainID(chainID),
 			)
 		},
-		GenesisState:  app.ModuleBasics.DefaultGenesis(encoding.Marshaler),
+		GenesisState:  tempApp.BasicModuleManager.DefaultGenesis(encoding.Marshaler),
 		TimeoutCommit: 2 * time.Second,
 		ChainID:       chainID,
 		// Some changes are introduced to make the tests run as if neutron is a standalone chain.

--- a/testutil/interchaintxs/network/network.go
+++ b/testutil/interchaintxs/network/network.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/log"
 	pruningtypes "cosmossdk.io/store/pruning/types"
 	db "github.com/cosmos/cosmos-db"
 	"github.com/stretchr/testify/require"
@@ -56,9 +57,26 @@ func New(t *testing.T, configs ...network.Config) *network.Network {
 // DefaultConfig will initialize config for the network with custom application,
 // genesis and single validator. All other parameters are inherited from cosmos-sdk/testutil/network.DefaultConfig
 func DefaultConfig() network.Config {
+	memoryDB := db.NewMemDB()
+
+	// TODO: move to depinject
+	// we "pre"-instantiate the application for getting the injected/configured encoding configuration
+	// note, this is not necessary when using app wiring, as depinject can be directly used
+	tempApp := app.New(
+		log.NewNopLogger(),
+		memoryDB,
+		nil,
+		false,
+		map[int64]bool{},
+		app.DefaultNodeHome,
+		0,
+		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
+		nil,
+	)
+
 	// app doesn't have these modules anymore, but we need them for test setup, which uses gentx and MsgCreateValidator
-	app.ModuleBasics[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
-	app.ModuleBasics[stakingtypes.ModuleName] = staking.AppModuleBasic{}
+	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
+	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModuleBasic{}
 
 	encoding := app.MakeEncodingConfig()
 	chainID := "chain-" + tmrand.NewRand().Str(6)
@@ -80,7 +98,6 @@ func DefaultConfig() network.Config {
 
 			return app.New(
 				val.GetCtx().Logger, db.NewMemDB(), nil, true, map[int64]bool{}, val.GetCtx().Config.RootDir, 0,
-				encoding,
 				sims.EmptyAppOptions{},
 				nil,
 				baseapp.SetPruning(pruningtypes.NewPruningOptionsFromString(val.GetAppConfig().Pruning)),
@@ -88,7 +105,7 @@ func DefaultConfig() network.Config {
 				baseapp.SetChainID(chainID),
 			)
 		},
-		GenesisState:  app.ModuleBasics.DefaultGenesis(encoding.Marshaler),
+		GenesisState:  tempApp.BasicModuleManager.DefaultGenesis(encoding.Marshaler),
 		TimeoutCommit: 2 * time.Second,
 		ChainID:       chainID,
 		// Some changes are introduced to make the tests run as if neutron is a standalone chain.

--- a/testutil/interchaintxs/network/network.go
+++ b/testutil/interchaintxs/network/network.go
@@ -73,12 +73,13 @@ func DefaultConfig() network.Config {
 		sims.NewAppOptionsWithFlagHome(app.DefaultNodeHome),
 		nil,
 	)
+	encoding := app.MakeEncodingConfig()
 
 	// app doesn't have these modules anymore, but we need them for test setup, which uses gentx and MsgCreateValidator
-	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModuleBasic{}
-	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModuleBasic{}
+	tempApp.BasicModuleManager[genutiltypes.ModuleName] = genutil.AppModule{}
+	tempApp.BasicModuleManager[stakingtypes.ModuleName] = staking.AppModule{}
+	tempApp.BasicModuleManager.RegisterInterfaces(encoding.InterfaceRegistry)
 
-	encoding := app.MakeEncodingConfig()
 	chainID := "chain-" + tmrand.NewRand().Str(6)
 	return network.Config{
 		Codec:             encoding.Marshaler,

--- a/testutil/test_helpers.go
+++ b/testutil/test_helpers.go
@@ -427,7 +427,6 @@ func SetupTestingApp(initValUpdates []cometbfttypes.ValidatorUpdate) func() (ibc
 			map[int64]bool{},
 			homePath,
 			0,
-			encoding,
 			sims.EmptyAppOptions{},
 			nil,
 		)
@@ -437,7 +436,7 @@ func SetupTestingApp(initValUpdates []cometbfttypes.ValidatorUpdate) func() (ibc
 		// and then we manually init baseapp and load states
 		testApp.LoadLatest()
 
-		genesisState := app.NewDefaultGenesisState(testApp.AppCodec())
+		genesisState := testApp.NewDefaultGenesisState()
 
 		// TODO: why isn't it in the `testApp.TestInitChainer`?
 		// NOTE ibc-go/v7/testing.SetupWithGenesisValSet requires a staking module


### PR DESCRIPTION
Initial commit, needs review - check the changes for anything missing

 if I overwrite the 'transfer' key in the newBasicModuleManager with neutron/x/transfer appModule, tests are failing with:
 `test panicked: failed to encode client state: *tendermint.ClientState does not have a registered interface`
 And if I don't, test are failing with an error that neutron.MsgTransfer TypeURL is not registered.
 
Edit: Since neutron/x/transfer module uses the storeKey and ModuleName from native ibctransfer, maybe we have a conflict with this new basicModuleManager? 