### PR TITLE
swap behind enemy lines

### DIFF
--- a/x/dex/keeper/core.go
+++ b/x/dex/keeper/core.go
@@ -65,6 +65,10 @@ func (k Keeper) DepositCore(
 			return nil, nil, nil, err
 		}
 
+		amount0, amount1, err = k.SwapPoolBehindEnemyLines(ctx, pool, amount0, amount1)
+		if err != nil {
+			return nil, nil, nil, types.ErrZeroTrueDeposit
+		}
 		existingShares := k.bankKeeper.GetSupply(ctx, pool.GetPoolDenom()).Amount
 
 		inAmount0, inAmount1, outShares := pool.Deposit(amount0, amount1, existingShares, autoswap)

--- a/x/dex/keeper/core_helper_test.go
+++ b/x/dex/keeper/core_helper_test.go
@@ -144,3 +144,61 @@ func (s *CoreHelpersTestSuite) TestGetCurrTick0To1WithMinLiq() {
 	s.Require().True(found)
 	s.Assert().Equal(int64(2), tickIdx)
 }
+
+// IsBehindEnemyLines /////////////////////////////////////////////////////////
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0BELHighTick() {
+	s.setLPAtFee1Pool(100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -102)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0BELLowTick() {
+	s.setLPAtFee1Pool(-100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 98)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0ValidHighTick() {
+	s.setLPAtFee1Pool(100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -101)
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken0ValidLowtick() {
+	s.setLPAtFee1Pool(-100, 0, 10)
+	tradePairID := types.MustNewTradePairID("TokenB", "TokenA")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 99)
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1BELLowTick() {
+	s.setLPAtFee1Pool(-10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -12)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1BELHighTick() {
+	s.setLPAtFee1Pool(10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 8)
+	s.True(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1ValidLowTick() {
+	s.setLPAtFee1Pool(-10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, -11)
+	s.False(isBEL)
+}
+
+func (s *CoreHelpersTestSuite) TestIsBehindEnemyLinesToken1ValidHighTick() {
+	s.setLPAtFee1Pool(10, 10, 0)
+	tradePairID := types.MustNewTradePairID("TokenA", "TokenB")
+	isBEL := s.app.DexKeeper.IsBehindEnemyLines(s.ctx, tradePairID, 9)
+	s.False(isBEL)
+}

--- a/x/dex/types/errors.go
+++ b/x/dex/types/errors.go
@@ -189,4 +189,9 @@ var (
 		1154,
 		"Swap amount too small; creates unfair spread for liquidity providers",
 	)
+	ErrDepositBothSidesBEL = sdkerrors.Register(
+		ModuleName,
+		1155,
+		"Cannot deposit into a pool with sides behind enemy lines",
+	)
 )


### PR DESCRIPTION
Swap LP deposits if they are behind enemy lines. This is a nice user convenience and prevents DOS dust attacks