### PR TITLE
Feat: whitelist ibc proposal messages

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -121,8 +121,8 @@ import (
 	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v8/modules/core"
-	ibcclient "github.com/cosmos/ibc-go/v8/modules/core/02-client"
-	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types" //nolint:staticcheck
+
+	//nolint:staticcheck
 	ibcporttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v8/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
@@ -719,9 +719,7 @@ func New(
 	// register the proposal types
 	adminRouterLegacy := govv1beta1.NewRouter()
 	adminRouterLegacy.AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
-		// AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(&app.UpgradeKeeper)).
-		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)) //nolint:staticcheck
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)) //nolint:staticcheck
 
 	app.AdminmoduleKeeper = *adminmodulekeeper.NewKeeper(
 		appCodec,

--- a/app/proposals_allowlisting.go
+++ b/app/proposals_allowlisting.go
@@ -64,6 +64,8 @@ func isSdkMessageWhitelisted(msg sdk.Msg) bool {
 		*wasmtypes.MsgUnpinCodes,
 		*upgradetypes.MsgSoftwareUpgrade,
 		*upgradetypes.MsgCancelUpgrade,
+		*ibcclienttypes.MsgRecoverClient,
+		*ibcclienttypes.MsgIBCSoftwareUpgrade,
 		*tokenfactorytypes.MsgUpdateParams,
 		*interchainqueriestypes.MsgUpdateParams,
 		*interchaintxstypes.MsgUpdateParams,

--- a/testutil/test_helpers.go
+++ b/testutil/test_helpers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tmrand "github.com/cometbft/cometbft/libs/rand"
+
 	"github.com/neutron-org/neutron/v4/utils"
 
 	"github.com/neutron-org/neutron/v4/app/config"

--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -3,7 +3,6 @@ package bindings
 
 import (
 	"cosmossdk.io/math"
-	cosmostypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	paramChange "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
@@ -105,8 +104,6 @@ type SubmitAdminProposal struct {
 
 type AdminProposal struct {
 	ParamChangeProposal    *ParamChangeProposal    `json:"param_change_proposal,omitempty"`
-	UpgradeProposal        *UpgradeProposal        `json:"upgrade_proposal,omitempty"`
-	ClientUpdateProposal   *ClientUpdateProposal   `json:"client_update_proposal,omitempty"`
 	ProposalExecuteMessage *ProposalExecuteMessage `json:"proposal_execute_message,omitempty"`
 }
 
@@ -141,20 +138,6 @@ type UpdateInterchainQuery struct {
 }
 
 type UpdateInterchainQueryResponse struct{}
-
-type UpgradeProposal struct {
-	Title               string           `json:"title,omitempty"`
-	Description         string           `json:"description,omitempty"`
-	Plan                Plan             `json:"plan"`
-	UpgradedClientState *cosmostypes.Any `json:"upgraded_client_state,omitempty"`
-}
-
-type ClientUpdateProposal struct {
-	Title              string `json:"title,omitempty"`
-	Description        string `json:"description,omitempty"`
-	SubjectClientId    string `json:"subject_client_id,omitempty"`
-	SubstituteClientId string `json:"substitute_client_id,omitempty"`
-}
 
 type ProposalExecuteMessage struct {
 	Message string `json:"message,omitempty"`

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -25,7 +25,6 @@ import (
 
 	paramChange "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 
-	softwareUpgrade "cosmossdk.io/x/upgrade/types"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -36,7 +35,7 @@ import (
 	admintypes "github.com/cosmos/admin-module/x/adminmodule/types"
 
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types" //nolint:staticcheck
+	//nolint:staticcheck
 
 	"github.com/neutron-org/neutron/v4/wasmbinding/bindings"
 	icqkeeper "github.com/neutron-org/neutron/v4/x/interchainqueries/keeper"
@@ -534,32 +533,6 @@ func (m *CustomMessenger) performSubmitAdminProposalLegacy(ctx sdk.Context, cont
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to set content on ParameterChangeProposal")
 		}
-	case proposal.UpgradeProposal != nil:
-		p := proposal.UpgradeProposal
-		err := msg.SetContent(&ibcclienttypes.UpgradeProposal{ //nolint:staticcheck
-			Title:       p.Title,
-			Description: p.Description,
-			Plan: softwareUpgrade.Plan{
-				Name:   p.Plan.Name,
-				Height: p.Plan.Height,
-				Info:   p.Plan.Info,
-			},
-			UpgradedClientState: p.UpgradedClientState,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to set content on UpgradeProposal")
-		}
-	case proposal.ClientUpdateProposal != nil:
-		p := proposal.ClientUpdateProposal
-		err := msg.SetContent(&ibcclienttypes.ClientUpdateProposal{ //nolint:staticcheck
-			Title:              p.Title,
-			Description:        p.Description,
-			SubjectClientId:    p.SubjectClientId,
-			SubstituteClientId: p.SubstituteClientId,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to set content on ClientUpdateProposal")
-		}
 	default:
 		return nil, errors.Wrapf(sdkerrors.ErrInvalidRequest, "unexpected legacy admin proposal structure: %+v", proposal)
 	}
@@ -1022,12 +995,6 @@ func (m *CustomMessenger) validateProposalQty(proposal *bindings.AdminProposal) 
 	if proposal.ParamChangeProposal != nil {
 		qty++
 	}
-	if proposal.ClientUpdateProposal != nil {
-		qty++
-	}
-	if proposal.UpgradeProposal != nil {
-		qty++
-	}
 	if proposal.ProposalExecuteMessage != nil {
 		qty++
 	}
@@ -1044,9 +1011,7 @@ func (m *CustomMessenger) validateProposalQty(proposal *bindings.AdminProposal) 
 
 func (m *CustomMessenger) isLegacyProposal(proposal *bindings.AdminProposal) bool {
 	switch {
-	case proposal.ParamChangeProposal != nil,
-		proposal.UpgradeProposal != nil,
-		proposal.ClientUpdateProposal != nil:
+	case proposal.ParamChangeProposal != nil:
 		return true
 	default:
 		return false

--- a/wasmbinding/test/custom_message_test.go
+++ b/wasmbinding/test/custom_message_test.go
@@ -602,11 +602,10 @@ func (suite *CustomMessengerTestSuite) TestTooMuchProposals() {
 	msg, err := json.Marshal(bindings.NeutronMsg{
 		SubmitAdminProposal: &bindings.SubmitAdminProposal{
 			AdminProposal: bindings.AdminProposal{
-				ClientUpdateProposal: &bindings.ClientUpdateProposal{
-					Title:              "aaa",
-					Description:        "ddafds",
-					SubjectClientId:    "sdfsdf",
-					SubstituteClientId: "sdfsd",
+				ParamChangeProposal: &bindings.ParamChangeProposal{
+					Title:        "aaa",
+					Description:  "ddafds",
+					ParamChanges: nil,
 				},
 				ProposalExecuteMessage: &bindings.ProposalExecuteMessage{Message: executeMsg},
 			},


### PR DESCRIPTION
We need to whitelist `RecoverClient` and `IBCSoftwareUpgrade` messages since old messages (`UpdateClient` and `UpgradeProposal` respectively) is [deprecated](https://github.com/cosmos/ibc-go/releases/tag/v8.0.0) in ibc-go v8.0+.

Related PRs:
* https://github.com/neutron-org/neutron-integration-tests/pull/297
* https://github.com/neutron-org/neutronjsplus/pull/37