### PR TITLE
Audit Fix: fee overflow

### DIFF
--- a/x/dex/keeper/msg_server_test.go
+++ b/x/dex/keeper/msg_server_test.go
@@ -1753,6 +1753,19 @@ func TestMsgDepositValidate(t *testing.T) {
 			},
 			types.ErrTickOutsideRange,
 		},
+		{
+			"invalid fee overflow",
+			types.MsgDeposit{
+				Creator:         sample.AccAddress(),
+				Receiver:        sample.AccAddress(),
+				Fees:            []uint64{559681},
+				TickIndexesAToB: []int64{0},
+				AmountsA:        []sdkmath.Int{sdkmath.OneInt()},
+				AmountsB:        []sdkmath.Int{sdkmath.OneInt()},
+				Options:         []*types.DepositOptions{{DisableAutoswap: false}},
+			},
+			types.ErrInvalidFee,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1872,6 +1885,17 @@ func TestMsgWithdrawalValidate(t *testing.T) {
 				SharesToRemove:  []sdkmath.Int{sdkmath.OneInt()},
 			},
 			types.ErrTickOutsideRange,
+		},
+		{
+			"invalid fee overflow",
+			types.MsgWithdrawal{
+				Creator:         sample.AccAddress(),
+				Receiver:        sample.AccAddress(),
+				Fees:            []uint64{559681},
+				TickIndexesAToB: []int64{0},
+				SharesToRemove:  []sdkmath.Int{sdkmath.OneInt()},
+			},
+			types.ErrInvalidFee,
 		},
 	}
 

--- a/x/dex/types/price.go
+++ b/x/dex/types/price.go
@@ -37,6 +37,10 @@ func IsTickOutOfRange(tickIndex int64) bool {
 }
 
 func ValidateTickFee(tick int64, fee uint64) error {
+	// Ensure we do not overflow/wrap Uint
+	if fee >= MaxTickExp {
+		return ErrInvalidFee
+	}
 	// Ensure |tick| + fee <= MaxTickExp
 	// NOTE: Ugly arithmetic is to ensure that we don't overflow uint64
 	if utils.Abs(tick) > MaxTickExp-fee {


### PR DESCRIPTION
From ottersec: 

We noticed a potential overflow issue ( overflow while casting uint64 to int64 )that passed ValidateBasic  and caused a protocol panic [here](https://github.com/neutron-org/neutron/blob/1d8794d85168b5d711c79c4617a79a3f1482f0cf/x/dex/keeper/pool.go#L37) when users withdraw with a fee greater than Max.int64. 


Solution: In ValidateTickFee we ensure that fee < MaxTickExp. This makes it impossible to overflow or wrap the tick uint