### PR TITLE
Feat/tranche purge event

### DIFF
--- a/x/dex/keeper/limit_order_expiration.go
+++ b/x/dex/keeper/limit_order_expiration.go
@@ -148,6 +148,8 @@ func (k Keeper) PurgeExpiredLimitOrders(ctx sdk.Context, curTime time.Time) {
 				k.SetInactiveLimitOrderTranche(ctx, tranche)
 				k.RemoveLimitOrderTranche(ctx, tranche.Key)
 				archivedTranches[string(val.TrancheRef)] = true
+
+				ctx.EventManager().EmitEvent(types.CreateTickUpdateLimitOrderTranchePurge(tranche))
 			}
 		}
 

--- a/x/dex/keeper/limit_order_expiration_test.go
+++ b/x/dex/keeper/limit_order_expiration_test.go
@@ -157,6 +157,13 @@ func (s *DexTestSuite) TestPurgeExpiredLimitOrders() {
 	s.Equal(yesterday, *inactiveTrancheList[0].ExpirationTime)
 	s.Equal(yesterday, *inactiveTrancheList[1].ExpirationTime)
 	s.Equal(now, *inactiveTrancheList[2].ExpirationTime)
+
+	// 3 TickUpdates are emitted for the expired tranches
+	s.AssertEventEmitted(s.Ctx, types.TickUpdateEventKey, 3)
+	updateEvent := s.FindEvent(ctx.EventManager().Events(), types.TickUpdateEventKey)
+	eventAttrs := s.ExtractAttributes(updateEvent)
+	// Event has Reserves == 0
+	s.Equal(eventAttrs[types.TickUpdateEventReserves], "0")
 }
 
 func (s *DexTestSuite) TestPurgeExpiredLimitOrdersAtBlockGasLimit() {

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -223,6 +223,19 @@ func CreateTickUpdateLimitOrderTranche(tranche *LimitOrderTranche) sdk.Event {
 	)
 }
 
+func CreateTickUpdateLimitOrderTranchePurge(tranche *LimitOrderTranche) sdk.Event {
+	tradePairID := tranche.Key.TradePairId
+	pairID := tradePairID.MustPairID()
+	return TickUpdateEvent(
+		pairID.Token0,
+		pairID.Token1,
+		tradePairID.MakerDenom,
+		tranche.Key.TickIndexTakerToMaker,
+		math.ZeroInt(),
+		sdk.NewAttribute(TickUpdateEventTrancheKey, tranche.Key.TrancheKey),
+	)
+}
+
 func GoodTilPurgeHitLimitEvent(gas types.Gas) sdk.Event {
 	attrs := []sdk.Attribute{
 		sdk.NewAttribute(sdk.AttributeKeyModule, "dex"),


### PR DESCRIPTION
In order for indexing services to work they must know when tranches are deleted. Currently, there are no TickUpdateEvents emitted when GTT and JIT limit orders are purged. This PR adds TickUpdateEvent as part of the purge process to fix this problem.  

https://hadronlabs.atlassian.net/jira/software/projects/DUAL/boards/9?selectedIssue=DUAL-22