### PR TITLE
Fix: temporary disable feemarket for make Slinky e2e tests work

### DIFF
--- a/tests/slinky/slinky_integration_test.go
+++ b/tests/slinky/slinky_integration_test.go
@@ -62,6 +62,10 @@ var (
 			Key:   "consensus.params.block.max_gas",
 			Value: "1000000000",
 		},
+		{
+			Key:   "app_state.feemarket.params.enabled",
+			Value: false,
+		},
 	}
 
 	denom = "untrn"


### PR DESCRIPTION
Temporary disable feemarket for make Slinky e2e tests work