### PR TITLE
feat: fallback to basic deductfee

### DIFF
--- a/network/init-neutrond.sh
+++ b/network/init-neutrond.sh
@@ -7,6 +7,7 @@ CHAINID=${CHAINID:-test-1}
 STAKEDENOM=${STAKEDENOM:-untrn}
 CONTRACTS_BINARIES_DIR=${CONTRACTS_BINARIES_DIR:-./contracts}
 THIRD_PARTY_CONTRACTS_DIR=${THIRD_PARTY_CONTRACTS_DIR:-./contracts_thirdparty}
+FEEMARKET_ENABLED=${FEEMARKET_ENABLED:-true}
 
 # IMPORTANT! minimum_gas_prices should always contain at least one record, otherwise the chain will not start or halt
 # ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 denom is required by intgration tests (test:tokenomics)
@@ -738,6 +739,7 @@ set_genesis_param_jq ".app_state.marketmap.params.market_authorities" "[\"$ADMIN
 set_genesis_param_jq ".app_state.feemarket.params.min_base_gas_price"    "\"0.0025\""                     # feemarket
 set_genesis_param_jq ".app_state.feemarket.params.fee_denom"       "\"untrn\""                            # feemarket
 set_genesis_param_jq ".app_state.feemarket.params.max_learning_rate" "\"0.5\""                            # feemarket
+set_genesis_param_jq ".app_state.feemarket.params.enabled" "$FEEMARKET_ENABLED"                            # feemarket
 set_genesis_param_jq ".app_state.feemarket.params.distribute_fees" "true"                                 # feemarket
 set_genesis_param_jq ".app_state.feemarket.state.base_gas_price" "\"0.0025\""                             # feemarket
 

--- a/network/init-neutrond.sh
+++ b/network/init-neutrond.sh
@@ -738,6 +738,7 @@ set_genesis_param_jq ".app_state.marketmap.params.market_authorities" "[\"$ADMIN
 set_genesis_param_jq ".app_state.feemarket.params.min_base_gas_price"    "\"0.0025\""                     # feemarket
 set_genesis_param_jq ".app_state.feemarket.params.fee_denom"       "\"untrn\""                            # feemarket
 set_genesis_param_jq ".app_state.feemarket.params.max_learning_rate" "\"0.5\""                            # feemarket
+set_genesis_param_jq ".app_state.feemarket.params.distribute_fees" "true"                                 # feemarket
 set_genesis_param_jq ".app_state.feemarket.state.base_gas_price" "\"0.0025\""                             # feemarket
 
 if ! jq -e . "$GENESIS_PATH" >/dev/null 2>&1; then


### PR DESCRIPTION
implemented decorator which switches between default cosmos-sdk FeeDecorator  and feemarket's one, depending on the `params.Enabled` field feemarket's module.

- [ ] integration tests pass