### PR TITLE
Fix: Genesis recreate for limitOrderExpirations & PoolIdRefs (v3.x Patch)

### DIFF
--- a/x/dex/genesis.go
+++ b/x/dex/genesis.go
@@ -17,7 +17,13 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 		case *types.TickLiquidity_PoolReserves:
 			k.SetPoolReserves(ctx, elem.GetPoolReserves())
 		case *types.TickLiquidity_LimitOrderTranche:
-			k.SetLimitOrderTranche(ctx, elem.GetLimitOrderTranche())
+			tranche := elem.GetLimitOrderTranche()
+			k.SetLimitOrderTranche(ctx, tranche)
+			if tranche.HasExpiration() {
+				// re-create expiration record
+				loExpiration := keeper.NewLimitOrderExpiration(tranche)
+				k.SetLimitOrderExpiration(ctx, loExpiration)
+			}
 		}
 	}
 	// Set all the inactiveLimitOrderTranche

--- a/x/dex/genesis.go
+++ b/x/dex/genesis.go
@@ -38,6 +38,8 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	// Set all the poolMetadata
 	for _, elem := range genState.PoolMetadataList {
 		k.SetPoolMetadata(ctx, elem)
+		// Store PoolID reference
+		k.StorePoolIDRef(ctx, elem.Id, elem.PairId, elem.Tick, elem.Fee)
 	}
 
 	// Set poolMetadata count

--- a/x/dex/genesis_test.go
+++ b/x/dex/genesis_test.go
@@ -101,6 +101,17 @@ func TestGenesis(t *testing.T) {
 					),
 				},
 			},
+			{
+				Liquidity: &types.TickLiquidity_PoolReserves{
+					PoolReserves: types.MustNewPoolReserves(
+						&types.PoolReservesKey{
+							TradePairId:           types.MustNewTradePairID("TokenA", "TokenB"),
+							TickIndexTakerToMaker: 0,
+							Fee:                   1,
+						},
+					),
+				},
+			},
 		},
 		InactiveLimitOrderTrancheList: []*types.LimitOrderTranche{
 			{
@@ -126,10 +137,16 @@ func TestGenesis(t *testing.T) {
 		},
 		PoolMetadataList: []types.PoolMetadata{
 			{
-				Id: 0,
+				PairId: types.MustNewPairID("TokenA", "TokenB"),
+				Tick:   0,
+				Fee:    1,
+				Id:     0,
 			},
 			{
-				Id: 1,
+				PairId: types.MustNewPairID("TokenA", "TokenB"),
+				Tick:   1,
+				Fee:    1,
+				Id:     1,
 			},
 		},
 		PoolCount: 2,
@@ -139,6 +156,7 @@ func TestGenesis(t *testing.T) {
 	k, ctx := keepertest.DexKeeper(t)
 	dex.InitGenesis(ctx, *k, genesisState)
 	got := dex.ExportGenesis(ctx, *k)
+	require.NotNil(t, got)
 
 	// check that LimitorderExpirations are recreated correctly
 	expectedLimitOrderExpirations := []*types.LimitOrderExpiration{
@@ -156,7 +174,10 @@ func TestGenesis(t *testing.T) {
 	require.Equal(t, *expectedLimitOrderExpirations[1], *loExpirations[1])
 	require.Equal(t, len(expectedLimitOrderExpirations), len(loExpirations))
 
-	require.NotNil(t, got)
+	// Check that poolID refs works
+
+	_, found := k.GetPool(ctx, types.MustNewPairID("TokenA", "TokenB"), 0, 1)
+	require.True(t, found)
 
 	nullify.Fill(&genesisState)
 	nullify.Fill(got)

--- a/x/dex/keeper/pool.go
+++ b/x/dex/keeper/pool.go
@@ -32,12 +32,12 @@ func (k Keeper) InitPool(
 ) (pool *types.Pool, err error) {
 	poolID := k.initializePoolMetadata(ctx, pairID, centerTickIndexNormalized, fee)
 
-	k.storePoolIDRef(ctx, poolID, pairID, centerTickIndexNormalized, fee)
+	k.StorePoolIDRef(ctx, poolID, pairID, centerTickIndexNormalized, fee)
 
 	return types.NewPool(pairID, centerTickIndexNormalized, fee, poolID)
 }
 
-func (k Keeper) storePoolIDRef(
+func (k Keeper) StorePoolIDRef(
 	ctx sdk.Context,
 	poolID uint64,
 	pairID *types.PairID,

--- a/x/dex/types/limit_order_tranche.go
+++ b/x/dex/types/limit_order_tranche.go
@@ -86,6 +86,10 @@ func (t LimitOrderTranche) IsFilled() bool {
 	return t.ReservesMakerDenom.IsZero()
 }
 
+func (t LimitOrderTranche) HasExpiration() bool {
+	return t.ExpirationTime != nil
+}
+
 func (t LimitOrderTranche) IsJIT() bool {
 	return t.ExpirationTime != nil && *t.ExpirationTime == JITGoodTilTime()
 }

--- a/x/dex/types/limit_order_tranche.go
+++ b/x/dex/types/limit_order_tranche.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -50,6 +52,7 @@ func MustNewLimitOrderTranche(
 	reservesTakerDenom math.Int,
 	totalMakerDenom math.Int,
 	totalTakerDenom math.Int,
+	expirationTime ...time.Time,
 ) *LimitOrderTranche {
 	limitOrderTranche, err := NewLimitOrderTranche(
 		makerDenom,
@@ -63,6 +66,14 @@ func MustNewLimitOrderTranche(
 	)
 	if err != nil {
 		panic(err)
+	}
+	switch len(expirationTime) {
+	case 0:
+		break
+	case 1:
+		limitOrderTranche.ExpirationTime = &expirationTime[0]
+	default:
+		panic("can only supply one expiration time")
 	}
 	return limitOrderTranche
 }


### PR DESCRIPTION
LimitOrder expirations were previously not recreated when loading from genesis file. This fix ensures that the expiration records are properly recreated.

Similarly, the PoolIdRef index was also not-recreated. This fix correctly rebuilds the PoolIdRefs.

This is a patch back-ported from https://github.com/neutron-org/neutron/pull/561