### PR TITLE
Allow FeeCollectorAddress to be valid when setting Tokenfactory params

### DIFF
--- a/testutil/tokenfactory/keeper/tokenfactory.go
+++ b/testutil/tokenfactory/keeper/tokenfactory.go
@@ -14,6 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/neutron-org/neutron/v4/testutil"
 	"github.com/neutron-org/neutron/v4/x/tokenfactory/keeper"
 	"github.com/neutron-org/neutron/v4/x/tokenfactory/types"
 )
@@ -43,7 +44,7 @@ func TokenFactoryKeeper(
 		accountKeeper,
 		bankKeeper,
 		contractKeeper,
-		"authority",
+		testutil.TestOwnerAddress,
 	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())

--- a/x/tokenfactory/keeper/msg_server_test.go
+++ b/x/tokenfactory/keeper/msg_server_test.go
@@ -869,24 +869,36 @@ func TestMsgUpdateParamsValidate(t *testing.T) {
 			"authority is invalid",
 		},
 		{
-			"empty fee_collector_address",
+			"empty fee_collector_address with denom_creation_fee",
 			types.MsgUpdateParams{
 				Authority: testutil.TestOwnerAddress,
 				Params: types.Params{
 					FeeCollectorAddress: "",
+					DenomCreationFee:    sdktypes.NewCoins(sdktypes.NewCoin("untrn", math.OneInt())),
 				},
 			},
-			"fee_collector_address is invalid",
+			"DenomCreationFee and FeeCollectorAddr must be both set or both unset",
+		},
+		{
+			"fee_collector_address empty denom_creation_fee",
+			types.MsgUpdateParams{
+				Authority: testutil.TestOwnerAddress,
+				Params: types.Params{
+					FeeCollectorAddress: testAddress,
+				},
+			},
+			"DenomCreationFee and FeeCollectorAddr must be both set or both unset",
 		},
 		{
 			"invalid fee_collector_address",
 			types.MsgUpdateParams{
 				Authority: testutil.TestOwnerAddress,
 				Params: types.Params{
+					DenomCreationFee:    sdktypes.NewCoins(sdktypes.NewCoin("untrn", math.OneInt())),
 					FeeCollectorAddress: "invalid fee_collector_address",
 				},
 			},
-			"fee_collector_address is invalid",
+			"failed to validate FeeCollectorAddress",
 		},
 	}
 

--- a/x/tokenfactory/types/tx.go
+++ b/x/tokenfactory/types/tx.go
@@ -32,11 +32,5 @@ func (msg *MsgUpdateParams) Validate() error {
 		return errorsmod.Wrap(err, "authority is invalid")
 	}
 
-	// TODO: This is inconsistent. Per Params.Validate() an empty creator address is valid as long as
-	// DenomCreationFee is nil. But This check fails if FeeCollectorAddress is unset.
-	if _, err := sdk.AccAddressFromBech32(msg.Params.FeeCollectorAddress); err != nil {
-		return errorsmod.Wrap(err, "fee_collector_address is invalid")
-	}
-
 	return msg.Params.Validate()
 }


### PR DESCRIPTION
This fixes the issue where MsgUpdateParams.Validate() only passes when FeeCollectorAddress is set. It should be possible to set params with an empty FeeCollectorAddress


**Integration Tests**

https://github.com/neutron-org/neutron-tests/actions/runs/9765613806