### PR TITLE
Add autocomplete generator to CLI

### DIFF
--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -113,6 +113,8 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		},
 	}
 
+	genAutoCompleteCmd(rootCmd)
+
 	initRootCmd(rootCmd, encodingConfig)
 	initClientCtx, err := config.ReadDefaultValuesFromDefaultClientConfig(initClientCtx)
 	if err != nil {
@@ -384,4 +386,36 @@ func setCustomEnvVariablesFromClientToml(ctx client.Context) {
 	setEnvFromConfig("fee-account", "NEUTROND_FEE_ACCOUNT")
 	// memo
 	setEnvFromConfig("note", "NEUTROND_NOTE")
+}
+
+func genAutoCompleteCmd(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "enable-cli-autocomplete [bash|zsh|fish|powershell]",
+		Short: "Generates cli completion scripts",
+		Long: `To configure your shell to load completions for each session, add to your profile:
+
+# bash example
+echo '. <(neutrond enable-cli-autocomplete bash)' >> ~/.bash_profile
+source ~/.bash_profile
+
+# zsh example
+echo '. <(neutrond enable-cli-autocomplete zsh)' >> ~/.zshrc
+source ~/.zshrc
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				_ = cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				_ = cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+		},
+	})
 }


### PR DESCRIPTION
This adds an autocomplete generator to the CLI that supports bash, zsh, fish and powershell.

This funcionality is part of [Cobra][1] so is available out of the box.

The code is taken from the [Osmosis][2] client.

[1]: https://pkg.go.dev/github.com/spf13/cobra#Command.GenBashCompletion
[2]: https://github.com/osmosis-labs/osmosis/blob/3999fb4e0c7045463ab5f1d9e1072fcb9070ade7/cmd/osmosisd/cmd/root.go#L1092
