### PR TITLE
fix: fix add-consumer-section for v4

### DIFF
--- a/cmd/neutrond/consumer.go
+++ b/cmd/neutrond/consumer.go
@@ -57,6 +57,7 @@ func AddConsumerSectionCmd(defaultNodeHome string) *cobra.Command {
 
 				genesisState.Provider.InitialValSet = initialValset
 				genesisState.Provider.ConsensusState.NextValidatorsHash = tmtypes.NewValidatorSet(vals).Hash()
+				state.AppGenesis.Consensus.Validators = []tmtypes.GenesisValidator{{Address: pk.Address(), PubKey: pk, Power: 100, Name: "val"}}
 
 				state.ConsumerModuleState = genesisState
 

--- a/cmd/neutrond/consumer.go
+++ b/cmd/neutrond/consumer.go
@@ -57,7 +57,7 @@ func AddConsumerSectionCmd(defaultNodeHome string) *cobra.Command {
 
 				genesisState.Provider.InitialValSet = initialValset
 				genesisState.Provider.ConsensusState.NextValidatorsHash = tmtypes.NewValidatorSet(vals).Hash()
-				state.AppGenesis.Consensus.Validators = []tmtypes.GenesisValidator{{Address: pk.Address(), PubKey: pk, Power: 100, Name: "val"}}
+				state.AppGenesis.Consensus.Validators = []tmtypes.GenesisValidator{{Address: pk.Address(), PubKey: pk, Power: 100}}
 
 				state.ConsumerModuleState = genesisState
 


### PR DESCRIPTION
wasn't working after upgrade to v4 - because of the new check on validating genesis