### PR TITLE
Fix deposit return values + add tests

### DIFF
--- a/x/dex/keeper/deposit.go
+++ b/x/dex/keeper/deposit.go
@@ -72,7 +72,7 @@ func (k Keeper) ExecuteDeposit(
 	tickIndices []int64,
 	fees []uint64,
 	options []*types.DepositOptions) (
-	amounts0Deposit, amounts1Deposit []math.Int,
+	amounts0Deposited, amounts1Deposited []math.Int,
 	totalAmountReserve0, totalAmountReserve1 math.Int,
 	sharesIssued sdk.Coins,
 	events sdk.Events,
@@ -81,8 +81,8 @@ func (k Keeper) ExecuteDeposit(
 ) {
 	totalAmountReserve0 = math.ZeroInt()
 	totalAmountReserve1 = math.ZeroInt()
-	amounts0Deposited := make([]math.Int, len(amounts0))
-	amounts1Deposited := make([]math.Int, len(amounts1))
+	amounts0Deposited = make([]math.Int, len(amounts0))
+	amounts1Deposited = make([]math.Int, len(amounts1))
 	sharesIssued = sdk.Coins{}
 
 	for i := 0; i < len(amounts0); i++ {
@@ -162,5 +162,5 @@ func (k Keeper) ExecuteDeposit(
 	// At this point shares issued is not sorted and may have duplicates
 	// we must sanitize to convert it to a valid set of coins
 	sharesIssued = utils.SanitizeCoins(sharesIssued)
-	return amounts0Deposit, amounts1Deposit, totalAmountReserve0, totalAmountReserve1, sharesIssued, events, failedDeposits, nil
+	return amounts0Deposited, amounts1Deposited, totalAmountReserve0, totalAmountReserve1, sharesIssued, events, failedDeposits, nil
 }

--- a/x/dex/keeper/integration_deposit_singlesided_test.go
+++ b/x/dex/keeper/integration_deposit_singlesided_test.go
@@ -271,13 +271,17 @@ func (s *DexTestSuite) TestDepositSingleSidedMultiA() {
 
 	// WHEN
 	// multi deposit
-	s.aliceDeposits(
+	resp := s.aliceDeposits(
 		NewDeposit(10, 0, 0, 1),
 		NewDeposit(10, 0, 0, 3),
 	)
 
 	// THEN
 	// assert 20 of token B deposited at tick 1 fee 0 and ticks unchanged
+	s.True(resp.Reserve0Deposited[0].Equal(sdkmath.NewInt(10000000)))
+	s.True(resp.Reserve0Deposited[1].Equal(sdkmath.NewInt(10000000)))
+	s.EqualValues([]sdkmath.Int{sdkmath.ZeroInt(), sdkmath.ZeroInt()}, resp.Reserve1Deposited)
+	s.EqualValues([]*types.FailedDeposit(nil), resp.FailedDeposits)
 	s.assertAliceBalances(20, 50)
 	s.assertDexBalances(30, 0)
 	s.assertPoolLiquidity(20, 0, 0, 1)
@@ -300,13 +304,17 @@ func (s *DexTestSuite) TestDepositSingleSidedMultiB() {
 
 	// WHEN
 	// multi deposit at
-	s.aliceDeposits(
+	resp := s.aliceDeposits(
 		NewDeposit(0, 10, 0, 1),
 		NewDeposit(0, 10, 0, 3),
 	)
 
 	// THEN
 	// assert 20 of token B deposited at tick 1 fee 0 and ticks unchanged
+	s.EqualValues([]sdkmath.Int{sdkmath.ZeroInt(), sdkmath.ZeroInt()}, resp.Reserve0Deposited)
+	s.True(resp.Reserve1Deposited[0].Equal(sdkmath.NewInt(10000000)))
+	s.True(resp.Reserve1Deposited[1].Equal(sdkmath.NewInt(10000000)))
+	s.EqualValues([]*types.FailedDeposit(nil), resp.FailedDeposits)
 	s.assertAliceBalances(50, 20)
 	s.assertDexBalances(0, 30)
 	s.assertPoolLiquidity(0, 20, 0, 1)

--- a/x/dex/keeper/msg_server_test.go
+++ b/x/dex/keeper/msg_server_test.go
@@ -521,29 +521,30 @@ func NewDepositWithOptions(
 	}
 }
 
-func (s *DexTestSuite) aliceDeposits(deposits ...*Deposit) {
-	s.depositsSuccess(s.alice, deposits)
+func (s *DexTestSuite) aliceDeposits(deposits ...*Deposit) *types.MsgDepositResponse {
+	return s.depositsSuccess(s.alice, deposits)
 }
 
-func (s *DexTestSuite) bobDeposits(deposits ...*Deposit) {
-	s.depositsSuccess(s.bob, deposits)
+func (s *DexTestSuite) bobDeposits(deposits ...*Deposit) *types.MsgDepositResponse {
+	return s.depositsSuccess(s.bob, deposits)
 }
 
-func (s *DexTestSuite) carolDeposits(deposits ...*Deposit) {
-	s.depositsSuccess(s.carol, deposits)
+func (s *DexTestSuite) carolDeposits(deposits ...*Deposit) *types.MsgDepositResponse {
+	return s.depositsSuccess(s.carol, deposits)
 }
 
-func (s *DexTestSuite) danDeposits(deposits ...*Deposit) {
-	s.depositsSuccess(s.dan, deposits)
+func (s *DexTestSuite) danDeposits(deposits ...*Deposit) *types.MsgDepositResponse {
+	return s.depositsSuccess(s.dan, deposits)
 }
 
 func (s *DexTestSuite) depositsSuccess(
 	account sdk.AccAddress,
 	deposits []*Deposit,
 	pairID ...types.PairID,
-) {
-	_, err := s.deposits(account, deposits, pairID...)
+) *types.MsgDepositResponse {
+	resp, err := s.deposits(account, deposits, pairID...)
 	s.Assert().Nil(err)
+	return resp
 }
 
 func (s *DexTestSuite) deposits(


### PR DESCRIPTION
Return values for deposit message were being returned incorrectly. This PR fixes the return values and adds tests. 