### PR TITLE
chore: added pruning cli

### DIFF
--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/client/pruning"
 	"io"
 	"os"
 	"path/filepath"
@@ -175,6 +176,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		queryCommand(),
 		txCommand(),
 		keys.Commands(),
+		pruning.Cmd(ac.newApp, app.DefaultNodeHome),
 	)
 }
 

--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -277,17 +277,6 @@ func (ac appCreator) newApp(
 		wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
 	}
 
-	chainID := cast.ToString(appOpts.Get(flags.FlagChainID))
-	if chainID == "" {
-		// fallback to genesis chain-id
-		appGenesis, err := genutiltypes.AppGenesisFromFile(filepath.Join(homeDir, cast.ToString(appOpts.Get("genesis_file"))))
-		if err != nil {
-			panic(err)
-		}
-
-		chainID = appGenesis.ChainID
-	}
-
 	return app.New(logger, db, traceStore, true, skipUpgradeHeights,
 		homeDir,
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
@@ -303,7 +292,6 @@ func (ac appCreator) newApp(
 		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
 		baseapp.SetSnapshot(snapshotStore, snapshottypes.SnapshotOptions{Interval: cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval)), KeepRecent: cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))}),
-		baseapp.SetChainID(chainID),
 	)
 }
 

--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -3,10 +3,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/client/pruning"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/cosmos/cosmos-sdk/client/pruning"
 
 	"cosmossdk.io/log"
 	"cosmossdk.io/store"

--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -278,6 +278,17 @@ func (ac appCreator) newApp(
 		wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
 	}
 
+	chainID := cast.ToString(appOpts.Get(flags.FlagChainID))
+	if chainID == "" {
+		// fallback to genesis chain-id
+		appGenesis, err := genutiltypes.AppGenesisFromFile(filepath.Join(homeDir, cast.ToString(appOpts.Get("genesis_file"))))
+		if err != nil {
+			panic(err)
+		}
+
+		chainID = appGenesis.ChainID
+	}
+
 	return app.New(logger, db, traceStore, true, skipUpgradeHeights,
 		homeDir,
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
@@ -293,6 +304,7 @@ func (ac appCreator) newApp(
 		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
 		baseapp.SetSnapshot(snapshotStore, snapshottypes.SnapshotOptions{Interval: cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval)), KeepRecent: cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))}),
+		baseapp.SetChainID(chainID),
 	)
 }
 


### PR DESCRIPTION
The pr brings a new root command to run a pruning process over an application without running node itself.
Also removed chain-id configuration in root cli, which was needed for auction lane. It's not needed anymore and it brakes a pruning command execution.