### PR TITLE
Chore: Add minAvgSellPrice attr to PlaceLimitOrderEvent

### DIFF
--- a/x/dex/keeper/grpc_query_simulate_place_limit_order.go
+++ b/x/dex/keeper/grpc_query_simulate_place_limit_order.go
@@ -43,7 +43,7 @@ func (k Keeper) SimulatePlaceLimitOrder(
 			return nil, errors.Wrapf(err, "invalid LimitSellPrice %s", msg.LimitSellPrice.String())
 		}
 	}
-	trancheKey, totalIn, takerCoinIn, takerCoinOut, _, err := k.ExecutePlaceLimitOrder(
+	trancheKey, totalIn, takerCoinIn, takerCoinOut, _, _, err := k.ExecutePlaceLimitOrder(
 		cacheCtx,
 		takerTradePairID,
 		msg.AmountIn,

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -7,6 +7,8 @@ import (
 	"cosmossdk.io/math"
 	"cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	math_utils "github.com/neutron-org/neutron/v5/utils/math"
 )
 
 // Shared Attributes
@@ -53,6 +55,7 @@ const (
 	AttributeTakerDenom           = "TakerDenom"
 	AttributeSharesOwned          = "SharesOwned"
 	AttributeSharesWithdrawn      = "SharesWithdrawn"
+	AttributeMinAvgSellPrice      = "MinAvgSellPrice"
 )
 
 // Event Keys
@@ -168,6 +171,7 @@ func CreatePlaceLimitOrderEvent(
 	amountIn math.Int,
 	limitTick int64,
 	orderType string,
+	minAvgSellPrice math_utils.PrecDec,
 	shares math.Int,
 	trancheKey string,
 	swapAmountIn math.Int,
@@ -189,6 +193,7 @@ func CreatePlaceLimitOrderEvent(
 		sdk.NewAttribute(AttributeTrancheKey, trancheKey),
 		sdk.NewAttribute(AttributeSwapAmountIn, swapAmountIn.String()),
 		sdk.NewAttribute(AttributeSwapAmountOut, swapAmountOut.String()),
+		sdk.NewAttribute(AttributeMinAvgSellPrice, minAvgSellPrice.String()),
 	}
 
 	return sdk.NewEvent(sdk.EventTypeMessage, attrs...)


### PR DESCRIPTION
Adds the MinAvgSellPrice to PlacePlaceLimitOrder event. This is a bit of a hacky fix, but is a smaller changeset, so easier to merge into current release. If this is not merged for the current release I will switch to the other branch with a more involved fix. 