### PR TITLE
fix: really removes tmp dir after cli run

### DIFF
--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -51,6 +51,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	// create a temporary application for use in constructing query + tx commands
 	initAppOptions := viper.New()
 	tempDir := tempDir()
+	// cleanup temp dir after we are done with the tempApp, so we don't leave behind a
+	// new temporary directory for every invocation. See https://github.com/CosmWasm/wasmd/issues/2017
+	defer os.RemoveAll(tempDir)
 	initAppOptions.Set(flags.FlagHome, tempDir)
 	tempApplication := app.New(
 		log.NewNopLogger(),
@@ -139,7 +142,6 @@ func tempDir() string {
 	if err != nil {
 		dir = app.DefaultNodeHome
 	}
-	defer os.RemoveAll(dir)
 
 	return dir
 }


### PR DESCRIPTION
Currently we get a new tmp dir every `/tmp/neutron*` after every cli call (any query or tx), and the dir never removed.
The PR fixes that.