### PR TITLE
fix: correct use of articles

### DIFF
--- a/app/genesis.go
+++ b/app/genesis.go
@@ -13,7 +13,7 @@ import (
 var FeeDenom = "untrn"
 
 // GenesisState is the genesis state of the blockchain represented here as a map of raw json
-// messages key'd by a identifier string.
+// messages key'd by an identifier string.
 // The identifier is used to determine which module genesis information belongs
 // to so it may be appropriately routed during init chain.
 // Within this application default genesis information is retrieved from

--- a/x/ibc-rate-limit/README.md
+++ b/x/ibc-rate-limit/README.md
@@ -216,7 +216,7 @@ is built on the `relay.SendTransfer()` in the transfer module and then passed to
 
 ##### Receives
 
-This behaves slightly different if the asset is an Neutron asset that was sent to the counterparty and is being
+This behaves slightly different if the asset is a Neutron asset that was sent to the counterparty and is being
 returned to the chain, or if the asset is being received by the chain and originates on the counterparty. In ibc this
 is called being a "source" or a "sink" respectively.
 


### PR DESCRIPTION
This pull request fixes incorrect article usage in two files:

- In `x/ibc-rate-limit/README.md`, changed "an Neutron asset" to "a Neutron asset" to match proper article usage for words starting with a consonant sound.
- In `app/genesis.go`, changed "a identifier string" to "an identifier string" to ensure the article is correctly used before a word starting with a vowel sound.

These changes improve readability and align with proper grammar rules.
