### PR TITLE
fix: typos in documentation files

### DIFF
--- a/x/ibc-rate-limit/README.md
+++ b/x/ibc-rate-limit/README.md
@@ -1,7 +1,7 @@
 # IBC Rate Limit
 
 The IBC Rate Limit module is responsible for adding a governance-configurable rate limit to IBC transfers.
-This is a safety control, intended to protect assets on Neutron in event of:
+This is a safety control, intended to protect assets on Neutron in the event of:
 
 * a bug/hack on Neutron
 * a bug/hack on the counter-party chain

--- a/x/tokenfactory/README.md
+++ b/x/tokenfactory/README.md
@@ -1,6 +1,6 @@
 # Token Factory (by Osmosis Labs)
 
-> This module was taken from Osmosis chain codebase (commit: https://github.com/osmosis-labs/osmosis/commit/9e178a631f91ffc91c51f3665ed915c9f15e1807). The reason of this action was to adopt module and tests to our codebase because it was not possible to import it without code modification
+> This module was taken from Osmosis chain codebase (commit: https://github.com/osmosis-labs/osmosis/commit/9e178a631f91ffc91c51f3665ed915c9f15e1807). The reason for this action was to adopt module and tests to our codebase because it was not possible to import it without code modification
 > that was made by Osmosis team to the original Cosmos SDK. These changes made it not possible (without deep modifications of the whole code) to import module to our code.
 > Also support of the creation fee was removed at the moment because we do not have community pool in the Neutron. 
 
@@ -73,7 +73,7 @@ message MsgBurn {
 ```
 
 **State Modifications:**
-- Saftey check the following
+- Safety check check the following
   - Check that the denom minting is created via `tokenfactory` module
   - Check that the sender of the message is the admin of the denom
 - Burn designated amount of tokens for the denom via `bank` module


### PR DESCRIPTION
Corrected `in event of` to `in the event of`
Corrected `The reason of this` to `The reason for this`
Corrected `Saftey` to `Safety`