### PR TITLE
fix in prec_dec.go

### DIFF
--- a/utils/math/prec_dec.go
+++ b/utils/math/prec_dec.go
@@ -718,7 +718,7 @@ func (d PrecDec) TruncatePrecDec() PrecDec {
 	return NewPrecDecFromBigInt(chopPrecisionAndTruncateNonMutative(d.i))
 }
 
-// Ceil returns the smallest interger value (as a decimal) that is greater than
+// Ceil returns the smallest integer value (as a decimal) that is greater than
 // or equal to the given decimal.
 func (d PrecDec) Ceil() PrecDec {
 	tmp := new(big.Int).Set(d.i)


### PR DESCRIPTION
### **Title**
Fix typo in `prec_dec.go`

---

### **Description**
This pull request addresses a minor typo in the `prec_dec.go` file. The correction ensures proper spelling and improves the clarity of the comment documentation.

---

### **Changes**
- Corrected "interger" to "integer" in the `Ceil` method documentation.

