### PR TITLE
Fix spelling error in `init-neutrond.sh`, `channel.proto`, and `limit_order_expiration.go`

### DIFF
--- a/network/init-neutrond.sh
+++ b/network/init-neutrond.sh
@@ -10,7 +10,7 @@ THIRD_PARTY_CONTRACTS_DIR=${THIRD_PARTY_CONTRACTS_DIR:-./contracts_thirdparty}
 FEEMARKET_ENABLED=${FEEMARKET_ENABLED:-true}
 
 # IMPORTANT! minimum_gas_prices should always contain at least one record, otherwise the chain will not start or halt
-# ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 denom is required by intgration tests (test:tokenomics)
+# ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 denom is required by integration tests (test:tokenomics)
 MIN_GAS_PRICES_DEFAULT='[{"denom":"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2","amount":"0"},{"denom":"untrn","amount":"0"}]'
 MIN_GAS_PRICES=${MIN_GAS_PRICES:-"$MIN_GAS_PRICES_DEFAULT"}
 

--- a/third_party/proto/ibc/core/channel/v1/channel.proto
+++ b/third_party/proto/ibc/core/channel/v1/channel.proto
@@ -141,7 +141,7 @@ message PacketState {
   bytes data = 4;
 }
 
-// PacketId is an identifer for a unique Packet
+// PacketId is an identifier for a unique Packet
 // Source chains refer to packets by source port/channel
 // Destination chains refer to packets by destination port/channel
 message PacketId {

--- a/x/dex/keeper/limit_order_expiration.go
+++ b/x/dex/keeper/limit_order_expiration.go
@@ -130,7 +130,7 @@ func (k Keeper) PurgeExpiredLimitOrders(ctx sdk.Context, curTime time.Time) {
 		if inGoodTilSegment && gasConsumed >= gasCutoff {
 
 			// If we hit our gas cutoff stop deleting so as not to timeout the block.
-			// We can only do this if we are proccesing normal GTT limitOrders
+			// We can only do this if we are processing normal GTT limitOrders
 			// and not JIT limit orders, since there is not protection in place
 			// to prevent JIT order from being traded on the next block.
 			// This is ok since only GT limit orders pose a meaningful attack


### PR DESCRIPTION
- **Fixed typo in `init-neutrond.sh`**  
  - "intgration" → "integration"  

- **Fixed typo in `channel.proto`**  
  - "identifer" → "identifier"  

- **Fixed typo in `limit_order_expiration.go`**  
  - "proccesing" → "processing"  

#### Modified Files:  
- `network/init-neutrond.sh`  
- `third_party/proto/ibc/core/channel/v1/channel.proto`  
- `x/dex/keeper/limit_order_expiration.go`  
