### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/testutil/apptesting/events.go
+++ b/testutil/apptesting/events.go
@@ -1,8 +1,9 @@
 package apptesting
 
 import (
+	"slices"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"golang.org/x/exp/slices"
 )
 
 // AssertEventEmitted asserts that ctx's event manager has emitted the given number of events

--- a/x/dex/keeper/core_helper.go
+++ b/x/dex/keeper/core_helper.go
@@ -1,10 +1,11 @@
 package keeper
 
 import (
+	"slices"
+
 	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"golang.org/x/exp/slices"
 
 	math_utils "github.com/neutron-org/neutron/v5/utils/math"
 	"github.com/neutron-org/neutron/v5/x/dex/types"

--- a/x/ibc-rate-limit/ibc_middleware_test.go
+++ b/x/ibc-rate-limit/ibc_middleware_test.go
@@ -2,6 +2,7 @@ package ibcratelimit_test
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/neutron-org/neutron/v5/testutil"
 


### PR DESCRIPTION
Since Go 1.21, the methods in x/exp used here can already be replaced by methods from the standard library