### PR TITLE
refactor: use maps.Clone to simplify the code and reorder packages

### DIFF
--- a/tests/dex/state_setup_test.go
+++ b/tests/dex/state_setup_test.go
@@ -2,6 +2,7 @@ package dex_state_test
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
 	"time"
 
@@ -409,17 +410,6 @@ func (s *DexStateTestSuite) SetupTest() {
 	s.msgServer = dexkeeper.NewMsgServerImpl(s.App.DexKeeper)
 }
 
-func cloneMap(original map[string]string) map[string]string {
-	// Create a new map
-	cloned := make(map[string]string)
-	// Copy each key-value pair from the original map to the new map
-	for key, value := range original {
-		cloned[key] = value
-	}
-
-	return cloned
-}
-
 type testParams struct {
 	field  string
 	states []string
@@ -439,7 +429,7 @@ func generatePermutations(testStates []testParams) []map[string]string {
 		// Iterate through all possible values and create new states
 		for _, value := range testStates[index].states {
 			fieldName := testStates[index].field
-			temp := cloneMap(current)
+			temp := maps.Clone(current)
 			temp[fieldName] = value
 			generate(index+1, temp)
 		}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Clone) added in the go1.21 standard library, which can make the code more concise and easy to read.