### PR TITLE
feat: allow indexers to know pool_id without a chain query

### DIFF
--- a/x/dex/keeper/deposit.go
+++ b/x/dex/keeper/deposit.go
@@ -176,6 +176,7 @@ func (k Keeper) ExecuteDeposit(
 			depositAmount1,
 			inAmount0,
 			inAmount1,
+			pool.Id,
 			outShares.Amount,
 		)
 		events = append(events, depositEvent)

--- a/x/dex/keeper/withdraw.go
+++ b/x/dex/keeper/withdraw.go
@@ -135,6 +135,7 @@ func (k Keeper) ExecuteWithdraw(
 			fee,
 			outAmount0,
 			outAmount1,
+			pool.Id,
 			sharesToRemove,
 		)
 		events = append(events, withdrawEvent)

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -30,7 +30,7 @@ const (
 	AttributeTickIndex            = "TickIndex"
 	AttributeFee                  = "Fee"
 	AttributeTrancheKey           = "TrancheKey"
-	AttributePoolId               = "PoolId"
+	AttributePoolID               = "PoolID"
 	AttributeSharesMinted         = "SharesMinted"
 	AttributeReserves0Deposited   = "ReservesZeroDeposited"
 	AttributeReserves1Deposited   = "ReservesOneDeposited"
@@ -91,7 +91,7 @@ func CreateDepositEvent(
 	depositAmountReserve1 math.Int,
 	amountIn0 math.Int,
 	amountIn1 math.Int,
-	poolId uint64,
+	poolID uint64,
 	sharesMinted math.Int,
 ) sdk.Event {
 	attrs := []sdk.Attribute{
@@ -105,7 +105,7 @@ func CreateDepositEvent(
 		sdk.NewAttribute(AttributeFee, strconv.FormatUint(fee, 10)),
 		sdk.NewAttribute(AttributeReserves0Deposited, depositAmountReserve0.String()),
 		sdk.NewAttribute(AttributeReserves1Deposited, depositAmountReserve1.String()),
-		sdk.NewAttribute(AttributePoolId, strconv.FormatUint(poolId, 10)),
+		sdk.NewAttribute(AttributePoolID, strconv.FormatUint(poolID, 10)),
 		sdk.NewAttribute(AttributeSharesMinted, sharesMinted.String()),
 		sdk.NewAttribute(AttributeAmountIn0, amountIn0.String()),
 		sdk.NewAttribute(AttributeAmountIn1, amountIn1.String()),
@@ -123,7 +123,7 @@ func CreateWithdrawEvent(
 	fee uint64,
 	withdrawAmountReserve0 math.Int,
 	withdrawAmountReserve1 math.Int,
-	poolId uint64,
+	poolID uint64,
 	sharesRemoved math.Int,
 ) sdk.Event {
 	attrs := []sdk.Attribute{
@@ -137,7 +137,7 @@ func CreateWithdrawEvent(
 		sdk.NewAttribute(AttributeFee, strconv.FormatUint(fee, 10)),
 		sdk.NewAttribute(AttributeReserves0Withdrawn, withdrawAmountReserve0.String()),
 		sdk.NewAttribute(AttributeReserves1Withdrawn, withdrawAmountReserve1.String()),
-		sdk.NewAttribute(AttributePoolId, strconv.FormatUint(poolId, 10)),
+		sdk.NewAttribute(AttributePoolID, strconv.FormatUint(poolID, 10)),
 		sdk.NewAttribute(AttributeSharesRemoved, sharesRemoved.String()),
 	}
 

--- a/x/dex/types/events.go
+++ b/x/dex/types/events.go
@@ -30,6 +30,7 @@ const (
 	AttributeTickIndex            = "TickIndex"
 	AttributeFee                  = "Fee"
 	AttributeTrancheKey           = "TrancheKey"
+	AttributePoolId               = "PoolId"
 	AttributeSharesMinted         = "SharesMinted"
 	AttributeReserves0Deposited   = "ReservesZeroDeposited"
 	AttributeReserves1Deposited   = "ReservesOneDeposited"
@@ -90,6 +91,7 @@ func CreateDepositEvent(
 	depositAmountReserve1 math.Int,
 	amountIn0 math.Int,
 	amountIn1 math.Int,
+	poolId uint64,
 	sharesMinted math.Int,
 ) sdk.Event {
 	attrs := []sdk.Attribute{
@@ -103,6 +105,7 @@ func CreateDepositEvent(
 		sdk.NewAttribute(AttributeFee, strconv.FormatUint(fee, 10)),
 		sdk.NewAttribute(AttributeReserves0Deposited, depositAmountReserve0.String()),
 		sdk.NewAttribute(AttributeReserves1Deposited, depositAmountReserve1.String()),
+		sdk.NewAttribute(AttributePoolId, strconv.FormatUint(poolId, 10)),
 		sdk.NewAttribute(AttributeSharesMinted, sharesMinted.String()),
 		sdk.NewAttribute(AttributeAmountIn0, amountIn0.String()),
 		sdk.NewAttribute(AttributeAmountIn1, amountIn1.String()),
@@ -120,6 +123,7 @@ func CreateWithdrawEvent(
 	fee uint64,
 	withdrawAmountReserve0 math.Int,
 	withdrawAmountReserve1 math.Int,
+	poolId uint64,
 	sharesRemoved math.Int,
 ) sdk.Event {
 	attrs := []sdk.Attribute{
@@ -133,6 +137,7 @@ func CreateWithdrawEvent(
 		sdk.NewAttribute(AttributeFee, strconv.FormatUint(fee, 10)),
 		sdk.NewAttribute(AttributeReserves0Withdrawn, withdrawAmountReserve0.String()),
 		sdk.NewAttribute(AttributeReserves1Withdrawn, withdrawAmountReserve1.String()),
+		sdk.NewAttribute(AttributePoolId, strconv.FormatUint(poolId, 10)),
 		sdk.NewAttribute(AttributeSharesRemoved, sharesRemoved.String()),
 	}
 


### PR DESCRIPTION
Currently there is no way to determine a dex pool's properties (`TickIndex` and `Fee`) from every possible dex deposit and withdrawal without performing a chain query (eg. `neutrond q dex show-pool-metadata 1`).

This is very inconvenient for indexers that are attempting to stream real-time data about user<>dex positions and user<>vault<>dex as they are being made, as the requirement to query the chain separately both complicates and slows down the process to stream the data. 

The easiest fix is to add the pool ID to the deposit and withdrawal events. An alternative approach would be a separate "new pool" event that would need to be before the deposit or withdrawal, however this is less convenient. It is helpful that the pool ID is attached to the related deposits and withdrawals as it provides an easy way to calculate the running total shares of each pool (sum of `SharesMinted - SharesRemoved`). 