### PR TITLE
Update broken Cosmos SDK Makefile link in README

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -3,4 +3,4 @@
 Thanks to the entire Cosmos SDK team and the contributors who put their efforts into making simulation testing
 easier to implement. 🤗
 
-https://github.com/cosmos/cosmos-sdk/blob/main/contrib/devtools/Makefile
+[Makefile](./Makefile)

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -3,4 +3,4 @@
 Thanks to the entire Cosmos SDK team and the contributors who put their efforts into making simulation testing
 easier to implement. 🤗
 
-https://github.com/cosmos/cosmos-sdk/blob/master/contrib/devtools/Makefile
+https://github.com/cosmos/cosmos-sdk/blob/main/contrib/devtools/Makefile


### PR DESCRIPTION
Replaced the outdated link to the Cosmos SDK Makefile in contrib/devtools/README.md with the current valid URL pointing to the main branch. This ensures contributors can access the correct Makefile reference.