### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -1105,13 +1106,7 @@ func (m *CustomMessenger) resubmitFailure(ctx sdk.Context, contractAddr sdk.AccA
 }
 
 func (m *CustomMessenger) isAdmin(ctx sdk.Context, contractAddr sdk.AccAddress) bool {
-	for _, admin := range m.AdminKeeper.GetAdmins(ctx) {
-		if admin == contractAddr.String() {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(m.AdminKeeper.GetAdmins(ctx), contractAddr.String())
 }
 
 func getRegisterFee(fee sdk.Coins) sdk.Coins {

--- a/x/revenue/keeper/twap.go
+++ b/x/revenue/keeper/twap.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"slices"
 
 	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
@@ -230,10 +231,8 @@ func (k *Keeper) getRewardAssetExponent(ctx sdk.Context) (uint32, error) {
 	}
 
 	for _, unit := range rewardAssetMd.DenomUnits {
-		for _, alias := range unit.Aliases {
-			if alias == rewardAssetMd.Symbol {
-				return unit.Exponent, nil
-			}
+		if slices.Contains(unit.Aliases, rewardAssetMd.Symbol) {
+			return unit.Exponent, nil
 		}
 	}
 	return 0, fmt.Errorf("couldn't find exponent for reward asset alias %s in reward denom metadata", rewardAssetMd.Symbol)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.