### PR TITLE
Fix Typos in IBC Proto Comments

### DIFF
--- a/third_party/proto/ibc/core/channel/v1/channel.proto
+++ b/third_party/proto/ibc/core/channel/v1/channel.proto
@@ -141,7 +141,7 @@ message PacketState {
   bytes data = 4;
 }
 
-// PacketId is an identifer for a unique Packet
+// PacketId is an identifier for a unique Packet
 // Source chains refer to packets by source port/channel
 // Destination chains refer to packets by destination port/channel
 message PacketId {

--- a/third_party/proto/ibc/core/connection/v1/connection.proto
+++ b/third_party/proto/ibc/core/connection/v1/connection.proto
@@ -94,7 +94,7 @@ message ConnectionPaths {
   repeated string paths = 2;
 }
 
-// Version defines the versioning scheme used to negotiate the IBC verison in
+// Version defines the versioning scheme used to negotiate the IBC version in
 // the connection handshake.
 message Version {
   option (gogoproto.goproto_getters) = false;


### PR DESCRIPTION
**Title:**  


**Description:**  
This pull request corrects minor typos in the comments of IBC proto files:
- Fixes the word "identifier" in `channel.proto`
- Fixes the word "version" in `connection.proto`

