### PR TITLE
Fix: incorrect panic message for price lookup

### DIFF
--- a/x/dex/types/price.go
+++ b/x/dex/types/price.go
@@ -69,7 +69,7 @@ func CalcPrice(relativeTickIndex int64) (math_utils.PrecDec, error) {
 
 func BinarySearchPriceToTick(price math_utils.PrecDec) uint64 {
 	if price.LT(math_utils.OnePrecDec()) {
-		panic("Can only lookup prices <= 1")
+		panic("Can only lookup prices >= 1")
 	}
 	var left uint64 // = 0
 	right := MaxTickExp


### PR DESCRIPTION
Sign on panic message is backwards