### PR TITLE
chore: fix proto script file handling and safety

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -4,19 +4,16 @@ set -eo pipefail
 
 protoc_install_proto_gen_doc() {
   echo "Installing protobuf protoc-gen-doc plugin"
-  (go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@latest 2> /dev/null)
+  go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@latest 2>/dev/null
 }
 
 echo "Generating gogo proto code"
-cd proto
-proto_dirs=$(find ./ -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
-for dir in $proto_dirs; do
-  for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
-    echo $file
-    if grep "option go_package" $file &> /dev/null ; then
-      buf generate --template buf.gen.gogo.yml $file
-    fi
-  done
+cd proto || exit 1
+find . -name '*.proto' -print0 | while IFS= read -r -d '' file; do
+  echo "$file"
+  if grep -q "option go_package" "$file"; then
+    buf generate --template buf.gen.gogo.yml "$file"
+  fi
 done
 
 #protoc_install_proto_gen_doc
@@ -27,5 +24,6 @@ done
 cd ..
 
 # move proto files to the right places
+mkdir -p x
 cp -r github.com/neutron-org/neutron/v8/x/* x/
-rm -rf github.com
+rm -rf github.com/neutron-org


### PR DESCRIPTION
* removed unnecessary `()` around `go install …` to avoid spawning a useless subshell.
* rewrote the file loop to safely handle `.proto` files with spaces or special characters:
  `for file in $(find …)` → `find … -print0 | while IFS= read -r -d '' file`.
* updated `grep "option go_package"` to `grep -q "option go_package" "$file"` for quiet search and proper quoting.
* added `cd proto || exit 1` to stop the script if the directory doesn’t exist.
* created the `x/` directory before copying files to prevent errors: `mkdir -p x`.
* narrowed down `rm -rf` to only remove the target subdirectory (`github.com/neutron-org`) instead of the whole `github.com`.

changes make the script safer, more robust, and prevent accidental deletion or errors when handling files with tricky names.
