### PR TITLE
refactor: use reflect.TypeFor

### DIFF
--- a/testutil/common/nullify/nullify.go
+++ b/testutil/common/nullify/nullify.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	coinType  = reflect.TypeOf(sdk.Coin{})
-	coinsType = reflect.TypeOf(sdk.Coins{})
+	coinType  = reflect.TypeFor[sdk.Coin]()
+	coinsType = reflect.TypeFor[sdk.Coins]()
 )
 
 // Fill analyze all struct fields and slices with

--- a/utils/dcli/parsers_test.go
+++ b/utils/dcli/parsers_test.go
@@ -152,7 +152,7 @@ func TestParseFieldFromArg(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			val := reflect.ValueOf(&tc.testingStruct).Elem()
-			typ := reflect.TypeOf(&tc.testingStruct).Elem()
+			typ := reflect.TypeFor[testingStruct]()
 
 			fVal := val.Field(tc.fieldIndex)
 			fType := typ.Field(tc.fieldIndex)


### PR DESCRIPTION
Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.

More info https://github.com/golang/go/issues/60088