### PR TITLE
refactor: use fmt.Appendf for improved performance

### DIFF
--- a/utils/math/prec_dec.go
+++ b/utils/math/prec_dec.go
@@ -771,9 +771,9 @@ func SortablePrecDecBytes(dec PrecDec) []byte {
 	}
 	// We move the negative sign to the front of all the left padded 0s, to make negative numbers come before positive numbers
 	if dec.IsNegative() {
-		return append([]byte("-"), []byte(fmt.Sprintf(fmt.Sprintf("%%0%ds", Precision*2+1), dec.Abs().String()))...)
+		return append([]byte("-"), fmt.Appendf(nil, fmt.Sprintf("%%0%ds", Precision*2+1), dec.Abs().String())...)
 	}
-	return []byte(fmt.Sprintf(fmt.Sprintf("%%0%ds", Precision*2+1), dec.String()))
+	return fmt.Appendf(nil, fmt.Sprintf("%%0%ds", Precision*2+1), dec.String())
 }
 
 // reuse nil values


### PR DESCRIPTION
 I modified the return statement to utilize fmt.Appendf instead of fmt.Sprintf for creating the formatted byte slice. 

This change enhances performance by directly appending the formatted string to the byte slice, avoiding the need for intermediate memory allocation created by fmt.Sprintf. 

The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.

 More info can see https://github.com/golang/go/issues/47579