### PR TITLE
chore: Fix incorrect function name in comment

### DIFF
--- a/x/dex/types/pool_denom.go
+++ b/x/dex/types/pool_denom.go
@@ -43,8 +43,8 @@ func ParsePoolIDFromDenom(denom string) (uint64, error) {
 	return idInt, nil
 }
 
-// NewDexMintCoinsRestriction creates and returns a BankMintingRestrictionFn that only allows minting of
-// valid pool denoms
+// NewDexDenomMintCoinsRestriction creates and returns a BankMintingRestrictionFn that only
+// allows minting of valid pool denoms
 func NewDexDenomMintCoinsRestriction() types.MintingRestrictionFn {
 	return func(_ context.Context, coinsToMint sdk.Coins) error {
 		for _, coin := range coinsToMint {

--- a/x/ibc-hooks/client/cli/query.go
+++ b/x/ibc-hooks/client/cli/query.go
@@ -32,7 +32,7 @@ func GetQueryCmd() *cobra.Command {
 	return cmd
 }
 
-// GetCmdPoolParams return pool params.
+// GetCmdWasmSender generates the local address for a wasm hooks sender.
 func GetCmdWasmSender() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wasm-sender <channelID> <originalSender>",


### PR DESCRIPTION
The comment now correctly matches the actual function name, improving code clarity and maintainability.