### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/utils/slice_helper.go
+++ b/utils/slice_helper.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"sort"
+	"slices"
 
 	"golang.org/x/exp/constraints"
 )
@@ -9,9 +9,7 @@ import (
 // SortSlice sorts a slice of type T elements that implement constraints.Ordered.
 // Mutates input slice s
 func SortSlice[T constraints.Ordered](s []T) {
-	sort.Slice(s, func(i, j int) bool {
-		return s[i] < s[j]
-	})
+	slices.Sort(s)
 }
 
 func Filter[T interface{}](filter func(T) bool, s []T) []T {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.