### PR TITLE
chore: fix inaccurate comment in NewProviderConsumerCoordinator function

### DIFF
--- a/testutil/test_helpers.go
+++ b/testutil/test_helpers.go
@@ -137,7 +137,7 @@ func testHomeDir(chainID string) string {
 	return path.Join(projectRoot, ".testchains", chainID)
 }
 
-// NewCoordinator initializes Coordinator with interchain security dummy provider and 2 neutron consumer chains
+// NewProviderConsumerCoordinator initializes Coordinator with interchain security dummy provider and 3 neutron consumer chains
 func NewProviderConsumerCoordinator(t *testing.T) *ibctesting.Coordinator {
 	coordinator := ibctesting.NewCoordinator(t, 0)
 	chainID := ibctesting.GetChainID(1)


### PR DESCRIPTION

The comment for the  `NewProviderConsumerCoordinator` function was incorrectly stating that it initializes 2 neutron consumer chains, while the actual implementation initializes 3 neutron consumer chains. 

The comment has been updated to accurately reflect the function's behavior.