### PR TITLE
feat: enabled pebble build flag, add snapshot subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ ifeq ($(WITH_CLEVELDB),yes)
   build_tags += gcc
 endif
 build_tags += $(BUILD_TAGS)
+build_tags += pebbledb
 build_tags := $(strip $(build_tags))
 
 build_tags_test_binary = $(build_tags)

--- a/cmd/neutrond/root.go
+++ b/cmd/neutrond/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
+	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -180,6 +181,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		queryCommand(),
 		txCommand(),
 		keys.Commands(),
+		snapshot.Cmd(ac.newApp),
 	)
 }
 


### PR DESCRIPTION
PR adds:
- added `snapshot` subcommand to manage local snapshots
- enabled pebble db. Now you can run you node with pebbledb backend by setting `db_backend` field in the config.toml to `pebbledb`