### PR TITLE
Chore: Improve Accuracy of PriceToTick Calculation

### DIFF
--- a/x/dex/keeper/integration_placelimitorder_test.go
+++ b/x/dex/keeper/integration_placelimitorder_test.go
@@ -345,8 +345,8 @@ func (s *DexTestSuite) TestPlaceLimitOrderWithPrice0To1() {
 	s.aliceWithdrawsLimitSell(trancheKey0)
 
 	// THEN alice gets out ~100 TOKENB and bob gets ~10 TOKENA
-	s.assertAliceBalancesInt(sdkmath.ZeroInt(), sdkmath.NewInt(99_999_999))
-	s.assertBobBalancesInt(sdkmath.NewInt(9999002), sdkmath.NewInt(0))
+	s.assertAliceBalancesInt(sdkmath.ZeroInt(), sdkmath.NewInt(99999977))
+	s.assertBobBalancesInt(sdkmath.NewInt(10000000), sdkmath.NewInt(22))
 }
 
 func (s *DexTestSuite) TestPlaceLimitOrderWithPrice1To0() {
@@ -364,7 +364,7 @@ func (s *DexTestSuite) TestPlaceLimitOrderWithPrice1To0() {
 
 	// THEN alice gets out ~10 TOKENA and bob gets ~40 TOKENB
 	s.assertAliceBalancesInt(sdkmath.NewInt(9999999), sdkmath.ZeroInt())
-	s.assertBobBalancesInt(sdkmath.ZeroInt(), sdkmath.NewInt(39997453))
+	s.assertBobBalancesInt(sdkmath.ZeroInt(), sdkmath.NewInt(40001452))
 }
 
 // Fill Or Kill limit orders ///////////////////////////////////////////////////////////

--- a/x/dex/types/price.go
+++ b/x/dex/types/price.go
@@ -81,9 +81,9 @@ BinarySearch:
 			// Use bottom logic
 			break BinarySearch
 		case PrecomputedPrices[mid].LT(price):
-			left = mid + 1
+			left = mid
 		default:
-			right = mid - 1
+			right = mid
 
 		}
 	}

--- a/x/dex/types/price_test.go
+++ b/x/dex/types/price_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	fmt "fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -65,15 +66,28 @@ func TestCalcTickIndexFromPrice(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			price, err1 := types.CalcPrice(tc.tick)
 			val, err2 := types.CalcTickIndexFromPrice(price)
-			if err1 != nil {
+			if tc.err {
 				require.Error(t, err1)
-				require.Error(t, err2)
 			} else {
 				// If we are not outside the tick range we should TestCalcTickIndexFromPrice to never throw
 				require.NoError(t, err1)
 				require.NoError(t, err2)
 				require.Equal(t, tc.tick, val)
 			}
+		})
+	}
+}
+
+func TestCalcTickIndexFromPriceFullRange(t *testing.T) {
+	for i := int64(types.MaxTickExp) * -1; i <= int64(types.MaxTickExp); i++ {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			price, err1 := types.CalcPrice(i)
+			val, err2 := types.CalcTickIndexFromPrice(price)
+			// If we are not outside the tick range we should TestCalcTickIndexFromPrice to never throw
+			require.NoError(t, err1)
+			require.NoError(t, err2)
+			require.Equal(t, i, val)
+
 		})
 	}
 }

--- a/x/dex/types/price_test.go
+++ b/x/dex/types/price_test.go
@@ -38,7 +38,7 @@ func TestCalcTickIndexFromPrice(t *testing.T) {
 		},
 		{
 			desc: "-200100",
-			tick: -2000100,
+			tick: -200100,
 		},
 		{
 			desc: "400000",


### PR DESCRIPTION
Fix the PriceToTickCalculation to ensure that the closest tick is always returned. Current code sometimes has an off-by-one error. 